### PR TITLE
Ability to show video recording only, Added a loading indicator when exporting logic gets executed.

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -29,6 +29,10 @@ public struct YPImagePickerConfiguration {
     /// Enables videos within the library and video taking. Defaults to false
     public var showsVideo = false
     
+    /// Enables videos only within the library and video taking. Defaults to false
+    /// If you set both showsVideo and showsVideOnly to true, showsVideoOnly will take priority.
+    public var showsVideoOnly = false
+    
     /// Enables selecting the front camera by default, useful for avatars. Defaults to false
     public var usesFrontCamera = false
     

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -39,7 +39,7 @@ public class YPImagePicker: UINavigationController {
     }
 
     public var didSelectImage: ((UIImage) -> Void)?
-    public var didSelectVideo: ((Data, UIImage) -> Void)?
+    public var didSelectVideo: ((Data, UIImage, URL) -> Void)?
     
     override public func viewDidLoad() {
         super.viewDidLoad()
@@ -89,14 +89,14 @@ public class YPImagePicker: UINavigationController {
                     case .completed:
                         if let videoData = FileManager.default.contents(atPath: uploadURL.path) {
                             DispatchQueue.main.async {
-                                self.didSelectVideo?(videoData, thumb)
+                                self.didSelectVideo?(videoData, thumb, uploadURL)
                             }
                         }
                     default:
                         // Fall back to default video size:
                         if let videoData = FileManager.default.contents(atPath: videoURL.path) {
                             DispatchQueue.main.async {
-                                self.didSelectVideo?(videoData, thumb)
+                                self.didSelectVideo?(videoData, thumb, uploadURL)
                             }
                         }
                     }

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -93,6 +93,7 @@ public class YPImagePicker: UINavigationController {
     override public func viewDidLoad() {
         super.viewDidLoad()
         viewControllers = [picker]
+        setupActivityIndicator()
         navigationBar.isTranslucent = false
         picker.didSelectImage = { [unowned self] pickedImage, isNewPhoto in
             if self.configuration.showsFilters {

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -89,7 +89,9 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         delegate = self
         
         if controllers.isEmpty {
-            if configuration.showsVideo {
+            if configuration.showsVideoOnly {
+                controllers = [videoVC]
+            } else if configuration.showsVideo {
                 controllers = [albumVC, cameraVC, videoVC]
             } else {
                 controllers = [albumVC, cameraVC]
@@ -105,7 +107,11 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
             startOnPage(1)
         case .video:
             mode = .video
-            startOnPage(configuration.showsVideo ? 2 : 1)
+            if configuration.showsVideoOnly {
+                startOnPage(0)
+            } else {
+                startOnPage(configuration.showsVideo ? 2 : 1)
+            }
         }
         
         updateMode(with: currentController)


### PR DESCRIPTION
- Added the ability to show only video recording
- Added a loading indicator when exporting logic gets executed. This process takes a long time to complete especially if you are recording more than 30 seconds.  By adding this loading view, the app feels more responsive and not frozen while performing this task.