### PR TITLE
Screens api

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -27,11 +27,11 @@ public struct YPImagePickerConfiguration {
     public var libraryTargetImageSize = YPLibraryImageSize.original
     
     /// Enables videos within the library and video taking. Defaults to false
+    @available(*, unavailable, renamed:"showsVideoInLibrary")
     public var showsVideo = false
     
-    /// Enables videos only within the library and video taking. Defaults to false
-    /// If you set both showsVideo and showsVideOnly to true, showsVideoOnly will take priority.
-    public var showsVideoOnly = false
+    /// Enables videos within the library. Defaults to false
+    public var showsVideoInLibrary = false
     
     /// Enables selecting the front camera by default, useful for avatars. Defaults to false
     public var usesFrontCamera = false
@@ -53,6 +53,10 @@ public struct YPImagePickerConfiguration {
     /// Defines which screen is shown at launch. Video mode will only work if `showsVideo = true`.
     /// Default value is `.photo`
     public var startOnScreen: YPPickerScreen = .photo
+    
+    /// Defines which screens are shown at launch, and their order.
+    /// Default value is `[.library, .photo, .video]`
+    public var screens: [YPPickerScreen] = [.library, .photo, .video]
     
     /// Defines the time limit for recording videos.
     /// Default is 30 seconds.

--- a/Source/Library/YPLibraryVC.swift
+++ b/Source/Library/YPLibraryVC.swift
@@ -72,6 +72,7 @@ public class YPLibraryVC: UIViewController, PermissionCheckable {
         super.viewWillDisappear(animated)
         pausePlayer()
         NotificationCenter.default.removeObserver(self)
+        PHPhotoLibrary.shared().unregisterChangeObserver(self)
     }
     
     // MARK: - Crop control

--- a/Source/Library/YPLibraryVC.swift
+++ b/Source/Library/YPLibraryVC.swift
@@ -149,12 +149,12 @@ public class YPLibraryVC: UIViewController, PermissionCheckable {
         options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
         
         if let collection = self.mediaManager.collection {
-            if !configuration.showsVideo {
+            if !configuration.showsVideoInLibrary {
                 options.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.image.rawValue)
             }
             mediaManager.fetchResult = PHAsset.fetchAssets(in: collection, options: options)
         } else {
-            mediaManager.fetchResult = configuration.showsVideo
+            mediaManager.fetchResult = configuration.showsVideoInLibrary
                 ? PHAsset.fetchAssets(with: options)
                 : PHAsset.fetchAssets(with: PHAssetMediaType.image, options: options)
         }

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -68,10 +68,13 @@ public class YPImagePicker: UINavigationController {
         loadingContainerView.frame = self.view.bounds
         
         loadingContainerView.addSubview(label)
-        let labelWidth:CGFloat = 200.0
-        let labelHeight:CGFloat = 20.0
-        let offset:CGFloat = 40.0
-        let frame = CGRect(x: (loadingContainerView.frame.width/2) - offset, y: (loadingContainerView.frame.height/2) + offset, width: labelWidth, height: labelHeight)
+        let labelWidth: CGFloat = 200.0
+        let labelHeight: CGFloat = 20.0
+        let offset: CGFloat = 40.0
+        let frame = CGRect(x: (loadingContainerView.frame.width/2) - offset,
+                           y: (loadingContainerView.frame.height/2) + offset,
+                           width: labelWidth,
+                           height: labelHeight)
         label.frame = frame
         
         loadingContainerView.addSubview(activityIndicatorView)
@@ -135,7 +138,8 @@ public class YPImagePicker: UINavigationController {
                     let uploadURL = URL(fileURLWithPath: path)
                     let asset = AVURLAsset(url: videoURL)
                     
-                    let exportSession = AVAssetExportSession(asset: asset, presetName: self.configuration.videoCompression)
+                    let exportSession = AVAssetExportSession(asset: asset,
+                                                             presetName: self.configuration.videoCompression)
                     exportSession?.outputURL = uploadURL
                     exportSession?.outputFileType = AVFileType.mov
                     exportSession?.shouldOptimizeForNetworkUse = true //USEFUL?

--- a/YPImagePickerExample/YPImagePickerExample/ViewController.swift
+++ b/YPImagePickerExample/YPImagePickerExample/ViewController.swift
@@ -40,12 +40,13 @@ class ViewController: UIViewController {
         config.onlySquareImagesFromLibrary = false
         config.onlySquareImagesFromCamera = true
 //        config.libraryTargetImageSize = .original
-        config.showsVideo = true //false
+        config.showsVideoInLibrary = true //false
 //        config.usesFrontCamera = true // false
 //        config.showsFilters = true
 //        config.shouldSaveNewPicturesToAlbum = true
         config.videoCompression = AVAssetExportPresetHighestQuality
         config.albumName = "MyGreatAppName"
+        config.screens = [.photo, .library] // customize screens and their order here.
         config.startOnScreen = .library
 //        config.videoRecordingTimeLimit = 10
 //        config.videoFromLibraryTimeLimit = 10
@@ -65,7 +66,7 @@ class ViewController: UIViewController {
             self.imageView.image = img
             picker.dismiss(animated: true, completion: nil)
         }
-        picker.didSelectVideo = { [unowned picker] videoData, videoThumbnailImage in
+        picker.didSelectVideo = { [unowned picker] videoData, videoThumbnailImage, url in
             // video picked
             self.imageView.image = videoThumbnailImage
             picker.dismiss(animated: true, completion: nil)


### PR DESCRIPTION
 @ChintanWeapp, @eddieespinal
Here is a demo of what we talked about earlier, a simple api to manage which screen type appears, and their order.

The api goes like this :
``` swift
config.screens = [.photo, .library] // customize screens and their order here.
config.startOnScreen = .library // which one should be shown first
```

In this case, `showsVideoOnly` will simply be replaced by  `config.screens = [.video]`

It looks like these two apis alone would enable a full customisation of every possible combination, while staying fairly simple to use.

Let me know your thoughts,