### PR TITLE
Crop

### DIFF
--- a/Source/Camera/YPCameraVC.swift
+++ b/Source/Camera/YPCameraVC.swift
@@ -215,7 +215,8 @@ public class YPCameraVC: UIViewController, UIGestureRecognizerDelegate, Permissi
                     }
                     
                     DispatchQueue.main.async {
-                        self.didCapturePhoto?(image)
+                        let noOrietationImage = image.resetOrientation()
+                        self.didCapturePhoto?(noOrietationImage)
                     }
                 }
             }
@@ -304,3 +305,4 @@ class YPPermissionDeniedPopup {
         return alert
     }
 }
+

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -65,4 +65,7 @@ public struct YPImagePickerConfiguration {
     /// Defines the time limit for videos from the library.
     /// Defaults to 60 seconds.
     public var videoFromLibraryTimeLimit: TimeInterval = 60.0
+    
+    /// Adds a Crop step in the photo taking process, after filters.  Defaults to .none
+    public var showsCrop: YPCropType = .none
 }

--- a/Source/Crop/YPCropVC.swift
+++ b/Source/Crop/YPCropVC.swift
@@ -1,0 +1,213 @@
+//
+//  YPCropVC.swift
+//  YPImagePicker
+//
+//  Created by Sacha DSO on 12/02/2018.
+//  Copyright © 2018 Yummypets. All rights reserved.
+//
+
+import UIKit
+
+public enum YPCropType {
+    case none
+    case rectangle(ratio: Double)
+//  TODO case circle
+}
+
+class YPCropVC: UIViewController {
+    
+    public var didFinishCropping: ((UIImage) -> Void)?
+    
+    override var prefersStatusBarHidden: Bool { return true }
+    
+    private let originalImage: UIImage
+    private let pinchGR = UIPinchGestureRecognizer()
+    private let panGR = UIPanGestureRecognizer()
+    
+    private let v: YPCropView
+    override func loadView() { view = v }
+    
+    required init(image: UIImage, ratio: Double) {
+        v = YPCropView(image: image, ratio: ratio)
+        originalImage = image
+        super.init(nibName: nil, bundle: nil)
+        self.title = "Crop"
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupToolbar()
+        setupGestureRecognizers()
+    }
+    
+    func setupToolbar() {
+        let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel,
+                                           target: self,
+                                           action: #selector(cancel))
+        cancelButton.tintColor = .white
+        
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        
+        let chooseButton = UIBarButtonItem(barButtonSystemItem: .save,
+                                           target: self,
+                                           action: #selector(done))
+        chooseButton.tintColor = .white
+        v.toolbar.items = [cancelButton, flexibleSpace, chooseButton]
+    }
+    
+    func setupGestureRecognizers() {
+        // Pinch Gesture
+        pinchGR.addTarget(self, action: #selector(pinch(_:)))
+        pinchGR.delegate = self
+        v.imageView.addGestureRecognizer(pinchGR)
+        
+        // Pan Gesture
+        panGR.addTarget(self, action: #selector(pan(_:)))
+        panGR.delegate = self
+        v.imageView.addGestureRecognizer(panGR)
+    }
+    
+    @objc
+    func cancel() {
+        navigationController?.popViewController(animated: true)
+    }
+    
+    @objc
+    func done() {
+        guard let image = v.imageView.image else {
+            return
+        }
+        
+        // TODO fix the crop ain't working yet
+        let scaleRatio = v.imageView.frame.width / image.size.width
+        var cropRect = view.convert(v.cropArea.frame, to: v.imageView)
+        
+        cropRect.origin.x = max(cropRect.origin.x, 0)
+        cropRect.origin.y = max(cropRect.origin.y, 0)
+        
+        // rect to actual coordinates (scale)
+        let scaledCropRect = CGRect(x: cropRect.minX * 1/scaleRatio,
+                                    y: cropRect.minY * 1/scaleRatio,
+                                    width: cropRect.width * 1/scaleRatio,
+                                    height: cropRect.height * 1/scaleRatio)
+        let imageRef = image.cgImage?.cropping(to: scaledCropRect)
+        let croppedImage = UIImage(cgImage: imageRef!, scale: UIScreen.main.scale, orientation: image.imageOrientation)
+        didFinishCropping?(croppedImage)
+    }
+}
+
+extension YPCropVC: UIGestureRecognizerDelegate {
+    
+    // MARK: - Pinch Gesture
+    
+    @objc
+    func pinch(_ sender: UIPinchGestureRecognizer) {
+        // TODO: Zoom where the fingers are (more user friendly)
+        switch sender.state {
+        case .began, .changed:
+            var transform = v.imageView.transform
+            // Apply zoom level.
+            transform = transform.scaledBy(x: sender.scale,
+                                            y: sender.scale)
+            v.imageView.transform = transform
+        case .ended:
+            var transform = v.imageView.transform
+            let kMinZoomLevel: CGFloat = 1.0
+            let kMaxZoomLevel: CGFloat = 3.0
+            var wentOutOfAllowedBounds = false
+            
+            // Prevent zooming out too much
+            if transform.a < kMinZoomLevel {
+                transform = .identity
+                wentOutOfAllowedBounds = true
+            }
+            
+            // Prevent zooming in too much
+            if transform.a > kMaxZoomLevel {
+                transform.a = kMaxZoomLevel
+                transform.d = kMaxZoomLevel
+                wentOutOfAllowedBounds = true
+            }
+            
+            // Animate coming back to the allowed bounds with a haptic feedback.
+            if wentOutOfAllowedBounds {
+                generateHapticFeedback()
+                UIView.animate(withDuration: 0.3, animations: {
+                    self.v.imageView.transform = transform
+                })
+            }
+        case .cancelled, .failed, .possible:
+            ()
+        }
+        // Reset the pinch scale.
+        sender.scale = 1.0
+    }
+    
+    func generateHapticFeedback() {
+        if #available(iOS 10.0, *) {
+            let generator = UIImpactFeedbackGenerator(style: .light)
+            generator.impactOccurred()
+        }
+    }
+    
+    // MARK: - Pan Gesture
+    
+    @objc
+    func pan(_ sender: UIPanGestureRecognizer) {
+        let translation = sender.translation(in: view)
+        let imageView = v.imageView
+        
+        // Apply the pan translation to the image.
+        imageView.center = CGPoint(x: imageView.center.x + translation.x, y: imageView.center.y + translation.y)
+        
+        // Reset the pan translation.
+        sender.setTranslation(CGPoint.zero, in: view)
+        
+        if sender.state == .ended {
+            keepImageIntoCropArea()
+        }
+    }
+    
+    private func keepImageIntoCropArea() {
+        let imageRect = v.imageView.frame
+        let cropRect = v.cropArea.frame
+        var correctedFrame = imageRect
+        
+        // Cap Top.
+        if imageRect.minY > cropRect.minY {
+            correctedFrame.origin.y = cropRect.minY
+        }
+        
+        // Cap Bottom.
+        if imageRect.maxY < cropRect.maxY {
+            correctedFrame.origin.y = cropRect.maxY - imageRect.height
+        }
+        
+        // Cap Left.
+        if imageRect.minX > cropRect.minX {
+            correctedFrame.origin.x = cropRect.minX
+        }
+        
+        // Cap Right.
+        if imageRect.maxX < cropRect.maxX {
+            correctedFrame.origin.x = cropRect.maxX - imageRect.width
+        }
+        
+        // Animate back to allowed bounds
+        if imageRect != correctedFrame {
+            UIView.animate(withDuration: 0.3, animations: {
+                self.v.imageView.frame = correctedFrame
+            })
+        }
+    }
+    
+    /// Allow both Pinching and Panning at the same time.
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                           shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
+    }
+}

--- a/Source/Crop/YPCropVC.swift
+++ b/Source/Crop/YPCropVC.swift
@@ -11,7 +11,6 @@ import UIKit
 public enum YPCropType {
     case none
     case rectangle(ratio: Double)
-//  TODO case circle
 }
 
 class YPCropVC: UIViewController {
@@ -115,36 +114,40 @@ extension YPCropVC: UIGestureRecognizerDelegate {
                                             y: sender.scale)
             v.imageView.transform = transform
         case .ended:
-            var transform = v.imageView.transform
-            let kMinZoomLevel: CGFloat = 1.0
-            let kMaxZoomLevel: CGFloat = 3.0
-            var wentOutOfAllowedBounds = false
-            
-            // Prevent zooming out too much
-            if transform.a < kMinZoomLevel {
-                transform = .identity
-                wentOutOfAllowedBounds = true
-            }
-            
-            // Prevent zooming in too much
-            if transform.a > kMaxZoomLevel {
-                transform.a = kMaxZoomLevel
-                transform.d = kMaxZoomLevel
-                wentOutOfAllowedBounds = true
-            }
-            
-            // Animate coming back to the allowed bounds with a haptic feedback.
-            if wentOutOfAllowedBounds {
-                generateHapticFeedback()
-                UIView.animate(withDuration: 0.3, animations: {
-                    self.v.imageView.transform = transform
-                })
-            }
+            pinchGestureEnded()
         case .cancelled, .failed, .possible:
             ()
         }
         // Reset the pinch scale.
         sender.scale = 1.0
+    }
+    
+    private func pinchGestureEnded() {
+        var transform = v.imageView.transform
+        let kMinZoomLevel: CGFloat = 1.0
+        let kMaxZoomLevel: CGFloat = 3.0
+        var wentOutOfAllowedBounds = false
+        
+        // Prevent zooming out too much
+        if transform.a < kMinZoomLevel {
+            transform = .identity
+            wentOutOfAllowedBounds = true
+        }
+        
+        // Prevent zooming in too much
+        if transform.a > kMaxZoomLevel {
+            transform.a = kMaxZoomLevel
+            transform.d = kMaxZoomLevel
+            wentOutOfAllowedBounds = true
+        }
+        
+        // Animate coming back to the allowed bounds with a haptic feedback.
+        if wentOutOfAllowedBounds {
+            generateHapticFeedback()
+            UIView.animate(withDuration: 0.3, animations: {
+                self.v.imageView.transform = transform
+            })
+        }
     }
     
     func generateHapticFeedback() {

--- a/Source/Crop/YPCropVC.swift
+++ b/Source/Crop/YPCropVC.swift
@@ -81,21 +81,23 @@ class YPCropVC: UIViewController {
             return
         }
         
-        // TODO fix the crop ain't working yet
-        let scaleRatio = v.imageView.frame.width / image.size.width
-        var cropRect = view.convert(v.cropArea.frame, to: v.imageView)
+        let xCrop = v.cropArea.frame.minX - v.imageView.frame.minX
+        let yCrop = v.cropArea.frame.minY - v.imageView.frame.minY
+        let widthCrop = v.cropArea.frame.width
+        let heightCrop = v.cropArea.frame.height
+        let scaleRatio = image.size.width / v.imageView.frame.width
+        let scaledCropRect = CGRect(x: xCrop * scaleRatio,
+                                    y: yCrop * scaleRatio,
+                                    width: widthCrop * scaleRatio,
+                                    height: heightCrop * scaleRatio)
         
-        cropRect.origin.x = max(cropRect.origin.x, 0)
-        cropRect.origin.y = max(cropRect.origin.y, 0)
-        
-        // rect to actual coordinates (scale)
-        let scaledCropRect = CGRect(x: cropRect.minX * 1/scaleRatio,
-                                    y: cropRect.minY * 1/scaleRatio,
-                                    width: cropRect.width * 1/scaleRatio,
-                                    height: cropRect.height * 1/scaleRatio)
-        let imageRef = image.cgImage?.cropping(to: scaledCropRect)
-        let croppedImage = UIImage(cgImage: imageRef!, scale: UIScreen.main.scale, orientation: image.imageOrientation)
-        didFinishCropping?(croppedImage)
+        if let imageRef = image.cgImage?.cropping(to: scaledCropRect) {
+            let croppedImage = UIImage(cgImage: imageRef,
+                                       scale: UIScreen.main.scale,
+                                       orientation: image.imageOrientation)
+            didFinishCropping?(croppedImage)
+        }
+
     }
 }
 

--- a/Source/Crop/YPCropVC.swift
+++ b/Source/Crop/YPCropVC.swift
@@ -90,11 +90,8 @@ class YPCropVC: UIViewController {
                                     y: yCrop * scaleRatio,
                                     width: widthCrop * scaleRatio,
                                     height: heightCrop * scaleRatio)
-        
         if let imageRef = image.cgImage?.cropping(to: scaledCropRect) {
-            let croppedImage = UIImage(cgImage: imageRef,
-                                       scale: UIScreen.main.scale,
-                                       orientation: image.imageOrientation)
+            let croppedImage = UIImage(cgImage: imageRef)
             didFinishCropping?(croppedImage)
         }
 

--- a/Source/Crop/YPCropView.swift
+++ b/Source/Crop/YPCropView.swift
@@ -1,0 +1,95 @@
+//
+//  YPCropView.swift
+//  YPImagePicker
+//
+//  Created by Sacha DSO on 12/02/2018.
+//  Copyright © 2018 Yummypets. All rights reserved.
+//
+
+import UIKit
+import Stevia
+
+class YPCropView: UIView {
+    
+    let imageView = UIImageView()
+    let topCurtain = UIView()
+    let cropArea = UIView()
+    let bottomCurtain = UIView()
+    let toolbar = UIToolbar()
+
+    convenience init(image: UIImage, ratio: Double) {
+        self.init(frame: .zero)
+        
+        // MARK: - View Hierarchy
+        
+        sv(
+            imageView,
+            topCurtain,
+            cropArea,
+            bottomCurtain,
+            toolbar
+        )
+        
+        // MARK: - Layout
+        
+        layout(
+            0,
+            |topCurtain|,
+            |cropArea|,
+            |bottomCurtain|,
+            0
+        )
+        |toolbar|
+        if #available(iOS 11.0, *) {
+            toolbar.Bottom == safeAreaLayoutGuide.Bottom
+        } else {
+            toolbar.bottom(0)
+        }
+        
+        let r: CGFloat = CGFloat(1.0 / ratio)
+        cropArea.Height == cropArea.Width * r
+        cropArea.centerVertically()
+        
+        // Fit image differently depnding on its ratio.
+        let imageRatio: Double = Double(image.size.width / image.size.height)
+        if ratio > imageRatio {
+            let scaledDownRatio = UIScreen.main.bounds.width / image.size.width
+            print(scaledDownRatio)
+            imageView.width(image.size.width * scaledDownRatio )
+            imageView.centerInContainer()
+        } else if ratio < imageRatio {
+            imageView.Height == cropArea.Height
+            imageView.centerInContainer()
+        } else {
+            imageView.followEdges(cropArea)
+        }
+        
+        // Fit imageView to image's bounds
+        imageView.Width == imageView.Height * CGFloat(imageRatio)
+        
+        // MARK: - Style
+        
+        backgroundColor = .black
+        imageView.style { i in
+            i.isUserInteractionEnabled = true
+            i.isMultipleTouchEnabled = true
+        }
+        topCurtain.style(curtainStyle)
+        cropArea.style { v in
+            v.backgroundColor = .clear
+            v.isUserInteractionEnabled = false
+        }
+        bottomCurtain.style(curtainStyle)
+        toolbar.style { t in
+            t.setBackgroundImage(UIImage(), forToolbarPosition: .any, barMetrics: .default)
+            t.setShadowImage(UIImage(), forToolbarPosition: .any)
+        }
+        
+        imageView.image = image
+    }
+    
+    func curtainStyle(v: UIView) {
+        v.backgroundColor = UIColor.black.withAlphaComponent(0.7)
+        v.isUserInteractionEnabled = false
+    }
+}

--- a/Source/Crop/YPCropView.swift
+++ b/Source/Crop/YPCropView.swift
@@ -74,6 +74,7 @@ class YPCropView: UIView {
     
     private func applyStyle() {
         backgroundColor = .black
+        clipsToBounds = true
         imageView.style { i in
             i.isUserInteractionEnabled = true
             i.isMultipleTouchEnabled = true

--- a/Source/Crop/YPCropView.swift
+++ b/Source/Crop/YPCropView.swift
@@ -19,9 +19,13 @@ class YPCropView: UIView {
 
     convenience init(image: UIImage, ratio: Double) {
         self.init(frame: .zero)
-        
-        // MARK: - View Hierarchy
-        
+        setupViewHierarchy()
+        setupLayout(with: image, ratio: ratio)
+        applyStyle()
+        imageView.image = image
+    }
+    
+    private func setupViewHierarchy() {
         sv(
             imageView,
             topCurtain,
@@ -29,9 +33,9 @@ class YPCropView: UIView {
             bottomCurtain,
             toolbar
         )
-        
-        // MARK: - Layout
-        
+    }
+    
+    private func setupLayout(with image: UIImage, ratio: Double) {
         layout(
             0,
             |topCurtain|,
@@ -66,9 +70,9 @@ class YPCropView: UIView {
         
         // Fit imageView to image's bounds
         imageView.Width == imageView.Height * CGFloat(imageRatio)
-        
-        // MARK: - Style
-        
+    }
+    
+    private func applyStyle() {
         backgroundColor = .black
         imageView.style { i in
             i.isUserInteractionEnabled = true
@@ -84,8 +88,6 @@ class YPCropView: UIView {
             t.setBackgroundImage(UIImage(), forToolbarPosition: .any, barMetrics: .default)
             t.setShadowImage(UIImage(), forToolbarPosition: .any)
         }
-        
-        imageView.image = image
     }
     
     func curtainStyle(v: UIView) {

--- a/Source/Crop/YPCropView.swift
+++ b/Source/Crop/YPCropView.swift
@@ -58,7 +58,6 @@ class YPCropView: UIView {
         let imageRatio: Double = Double(image.size.width / image.size.height)
         if ratio > imageRatio {
             let scaledDownRatio = UIScreen.main.bounds.width / image.size.width
-            print(scaledDownRatio)
             imageView.width(image.size.width * scaledDownRatio )
             imageView.centerInContainer()
         } else if ratio < imageRatio {

--- a/Source/Helpers/UIImage+ResetOrientation.swift
+++ b/Source/Helpers/UIImage+ResetOrientation.swift
@@ -1,0 +1,76 @@
+//
+//  UIImage+ResetOrientation.swift
+//  YPImagePicker
+//
+//  Created by Sacha DSO on 20/02/2018.
+//  Copyright © 2018 Yummypets. All rights reserved.
+//
+
+import UIKit
+
+extension UIImage {
+    
+    /// Kudos to Trevor Harmon and his UIImage+Resize category from
+    // which this code is heavily inspired.
+    func resetOrientation() -> UIImage {
+        
+        // Image has no orientation, so keep the same
+        if imageOrientation == .up {
+            return self
+        }
+        
+        // Process the transform corresponding to the current orientation
+        var transform = CGAffineTransform.identity
+        switch imageOrientation {
+        case .down, .downMirrored:           // EXIF = 3, 4
+            transform = transform.translatedBy(x: size.width, y: size.height)
+            transform = transform.rotated(by: CGFloat(Double.pi))
+            
+        case .left, .leftMirrored:           // EXIF = 6, 5
+            transform = transform.translatedBy(x: size.width, y: 0)
+            transform = transform.rotated(by: CGFloat(Double.pi / 2))
+            
+        case .right, .rightMirrored:          // EXIF = 8, 7
+            transform = transform.translatedBy(x: 0, y: size.height)
+            transform = transform.rotated(by: -CGFloat((Double.pi / 2)))
+        default:
+            ()
+        }
+        
+        switch imageOrientation {
+        case .upMirrored, .downMirrored:     // EXIF = 2, 4
+            transform = transform.translatedBy(x: size.width, y: 0)
+            transform = transform.scaledBy(x: -1, y: 1)
+            
+        case .leftMirrored, .rightMirrored:   //EXIF = 5, 7
+            transform = transform.translatedBy(x: size.height, y: 0)
+            transform = transform.scaledBy(x: -1, y: 1)
+        default:
+            ()
+        }
+        
+        // Draw a new image with the calculated transform
+        let context = CGContext(data: nil,
+                                width: Int(size.width),
+                                height: Int(size.height),
+                                bitsPerComponent: cgImage!.bitsPerComponent,
+                                bytesPerRow: 0,
+                                space: cgImage!.colorSpace!,
+                                bitmapInfo: cgImage!.bitmapInfo.rawValue)
+        context?.concatenate(transform)
+        switch imageOrientation {
+        case .left, .leftMirrored, .right, .rightMirrored:
+            context?.draw(cgImage!, in: CGRect(x: 0, y: 0, width: size.height, height: size.width))
+        default:
+            context?.draw(cgImage!, in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
+        }
+        
+        if let newImageRef =  context?.makeImage() {
+            let newImage = UIImage(cgImage: newImageRef)
+            return newImage
+        }
+        
+        // In case things go wrong, still return self.
+        return self
+    }
+}

--- a/Source/Library/YPLibraryVC.swift
+++ b/Source/Library/YPLibraryVC.swift
@@ -230,7 +230,7 @@ public class YPLibraryVC: UIViewController, PermissionCheckable {
     
     private func fetchImage(for asset: PHAsset, callback: @escaping (_ photo: UIImage) -> Void) {
         delegate?.libraryViewStartedLoadingImage()
-        let cropRect = v.currentCropRect()
+        let cropRect = DispatchQueue.main.sync { v.currentCropRect() }
         let ts = targetSize(for: asset, cropRect: cropRect)
         mediaManager.imageManager?.fetchImage(for: asset, cropRect: cropRect, targetSize: ts, callback: callback)
     }

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -102,9 +102,17 @@ public class YPImagePicker: UINavigationController {
             if self.configuration.showsFilters {
                 let filterVC = YPFiltersVC(image: pickedImage)
                 filterVC.didSelectImage = { filteredImage, isImageFiltered in
-                    self.didSelectImage?(filteredImage)
-                    if (isNewPhoto || isImageFiltered) && self.configuration.shouldSaveNewPicturesToAlbum {
-                        YPPhotoSaver.trySaveImage(filteredImage, inAlbumNamed: self.configuration.albumName)
+                    if case let YPCropType.rectangle(ratio) = self.configuration.showsCrop {
+                        let cropVC = YPCropVC(image: filteredImage, ratio: ratio)
+                        cropVC.didFinishCropping = { croppedImage in
+                            self.didSelectImage?(croppedImage)
+                        }
+                        self.pushViewController(cropVC, animated: true)
+                    } else {
+                        self.didSelectImage?(filteredImage)
+                        if (isNewPhoto || isImageFiltered) && self.configuration.shouldSaveNewPicturesToAlbum {
+                            YPPhotoSaver.trySaveImage(filteredImage, inAlbumNamed: self.configuration.albumName)
+                        }
                     }
                 }
                 

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -117,7 +117,6 @@ public class YPImagePicker: UINavigationController {
                         }
                         self.pushViewController(cropVC, animated: true)
                     } else {
-                        self.didSelectImage?(filteredImage)
                         completion(filteredImage)
                     }
                 }

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -102,17 +102,23 @@ public class YPImagePicker: UINavigationController {
             if self.configuration.showsFilters {
                 let filterVC = YPFiltersVC(image: pickedImage)
                 filterVC.didSelectImage = { filteredImage, isImageFiltered in
+                    
+                    let completion = { (image: UIImage) in
+                        self.didSelectImage?(image)
+                        if (isNewPhoto || isImageFiltered) && self.configuration.shouldSaveNewPicturesToAlbum {
+                            YPPhotoSaver.trySaveImage(filteredImage, inAlbumNamed: self.configuration.albumName)
+                        }
+                    }
+                    
                     if case let YPCropType.rectangle(ratio) = self.configuration.showsCrop {
                         let cropVC = YPCropVC(image: filteredImage, ratio: ratio)
                         cropVC.didFinishCropping = { croppedImage in
-                            self.didSelectImage?(croppedImage)
+                            completion(croppedImage)
                         }
                         self.pushViewController(cropVC, animated: true)
                     } else {
                         self.didSelectImage?(filteredImage)
-                        if (isNewPhoto || isImageFiltered) && self.configuration.shouldSaveNewPicturesToAlbum {
-                            YPPhotoSaver.trySaveImage(filteredImage, inAlbumNamed: self.configuration.albumName)
-                        }
+                        completion(filteredImage)
                     }
                 }
                 
@@ -125,9 +131,20 @@ public class YPImagePicker: UINavigationController {
                 
                 self.pushViewController(filterVC, animated: false)
             } else {
-                self.didSelectImage?(pickedImage)
-                if isNewPhoto && self.configuration.shouldSaveNewPicturesToAlbum {
-                    YPPhotoSaver.trySaveImage(pickedImage, inAlbumNamed: self.configuration.albumName)
+                let completion = { (image: UIImage) in
+                    self.didSelectImage?(image)
+                    if isNewPhoto && self.configuration.shouldSaveNewPicturesToAlbum {
+                        YPPhotoSaver.trySaveImage(pickedImage, inAlbumNamed: self.configuration.albumName)
+                    }
+                }
+                if case let YPCropType.rectangle(ratio) = self.configuration.showsCrop {
+                    let cropVC = YPCropVC(image: pickedImage, ratio: ratio)
+                    cropVC.didFinishCropping = { croppedImage in
+                        completion(croppedImage)
+                    }
+                    self.pushViewController(cropVC, animated: true)
+                } else {
+                    completion(pickedImage)
                 }
             }
         }

--- a/YPImagePicker.xcodeproj/project.pbxproj
+++ b/YPImagePicker.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		99A0529F1F20B480005600B3 /* YPAlbumCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A0529E1F20B480005600B3 /* YPAlbumCell.swift */; };
 		99A052A11F20B49B005600B3 /* YPAlbum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A052A01F20B49B005600B3 /* YPAlbum.swift */; };
 		99A052A31F20B4CA005600B3 /* YPAlbumsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A052A21F20B4CA005600B3 /* YPAlbumsManager.swift */; };
+		99A3C91020319227008D7E23 /* YPCropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A3C90F20319227008D7E23 /* YPCropView.swift */; };
+		99A3C91220319231008D7E23 /* YPCropVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A3C91120319231008D7E23 /* YPCropVC.swift */; };
 		99C6D6B91F1FB5C100711DB2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 99C6D6981F1FB5C100711DB2 /* Assets.xcassets */; };
 		99C6D6BA1F1FB5C100711DB2 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 99C6D6991F1FB5C100711DB2 /* Localizable.strings */; };
 		99C6D6BB1F1FB5C100711DB2 /* YPLibraryVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C6D69F1F1FB5C100711DB2 /* YPLibraryVC.swift */; };
@@ -76,6 +78,8 @@
 		99A0529E1F20B480005600B3 /* YPAlbumCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPAlbumCell.swift; sourceTree = "<group>"; };
 		99A052A01F20B49B005600B3 /* YPAlbum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPAlbum.swift; sourceTree = "<group>"; };
 		99A052A21F20B4CA005600B3 /* YPAlbumsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPAlbumsManager.swift; sourceTree = "<group>"; };
+		99A3C90F20319227008D7E23 /* YPCropView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPCropView.swift; sourceTree = "<group>"; };
+		99A3C91120319231008D7E23 /* YPCropVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPCropVC.swift; sourceTree = "<group>"; };
 		99C6D6981F1FB5C100711DB2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		99C6D69A1F1FB5C100711DB2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		99C6D69B1F1FB5C100711DB2 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -194,6 +198,15 @@
 			name = Albums;
 			sourceTree = "<group>";
 		};
+		99A3C90E20319212008D7E23 /* Crop */ = {
+			isa = PBXGroup;
+			children = (
+				99A3C91120319231008D7E23 /* YPCropVC.swift */,
+				99A3C90F20319227008D7E23 /* YPCropView.swift */,
+			);
+			path = Crop;
+			sourceTree = "<group>";
+		};
 		99C6D6971F1FB5C100711DB2 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -216,6 +229,7 @@
 				99C6D6A61F1FB5C100711DB2 /* Camera */,
 				99C6D6B61F1FB5C100711DB2 /* Video */,
 				99C6D6A91F1FB5C100711DB2 /* Filters */,
+				99A3C90E20319212008D7E23 /* Crop */,
 				99019E542018CECC007325C2 /* Helpers */,
 			);
 			path = Source;
@@ -386,6 +400,7 @@
 				99CF6D21201B70A000487F77 /* YPLibraryVC+CollectionView.swift in Sources */,
 				99CF6D1B201B6A5C00487F77 /* UICollectionView+IndexPath.swift in Sources */,
 				99C6D6C11F1FB5C100711DB2 /* YPImageCropViewContainer.swift in Sources */,
+				99A3C91020319227008D7E23 /* YPCropView.swift in Sources */,
 				99C6D6D11F1FB5C100711DB2 /* YPImagePicker.swift in Sources */,
 				99019E4C2018CCD6007325C2 /* YPBottomPagerView.swift in Sources */,
 				99C6D6BB1F1FB5C100711DB2 /* YPLibraryVC.swift in Sources */,
@@ -406,6 +421,7 @@
 				99A052A31F20B4CA005600B3 /* YPAlbumsManager.swift in Sources */,
 				99A0529F1F20B480005600B3 /* YPAlbumCell.swift in Sources */,
 				99C6D6BC1F1FB5C100711DB2 /* YPLibraryView.swift in Sources */,
+				99A3C91220319231008D7E23 /* YPCropVC.swift in Sources */,
 				99019E512018CDED007325C2 /* YPLibraryImageSize.swift in Sources */,
 				99CF6D25201B727900487F77 /* YPLibraryVC+PanGesture.swift in Sources */,
 				99CF6D27201B739600487F77 /* YPAlerts.swift in Sources */,

--- a/YPImagePicker.xcodeproj/project.pbxproj
+++ b/YPImagePicker.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		990FD295201B3E59002A39A1 /* YPDragDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990FD294201B3E59002A39A1 /* YPDragDirection.swift */; };
 		990FD297201B4A5F002A39A1 /* PHCachingImageManager+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990FD296201B4A5F002A39A1 /* PHCachingImageManager+Helpers.swift */; };
 		990FD299201B67FE002A39A1 /* PHFetchResult + IndexPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990FD298201B67FE002A39A1 /* PHFetchResult + IndexPath.swift */; };
+		9911FA24203C3A31000E9B06 /* UIImage+ResetOrientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9911FA23203C3A31000E9B06 /* UIImage+ResetOrientation.swift */; };
 		99A0529A1F20A19B005600B3 /* YPAlbumVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A052991F20A19B005600B3 /* YPAlbumVC.swift */; };
 		99A0529D1F20B45D005600B3 /* YPAlbumView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A0529C1F20B45D005600B3 /* YPAlbumView.swift */; };
 		99A0529F1F20B480005600B3 /* YPAlbumCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A0529E1F20B480005600B3 /* YPAlbumCell.swift */; };
@@ -73,6 +74,7 @@
 		990FD294201B3E59002A39A1 /* YPDragDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPDragDirection.swift; sourceTree = "<group>"; };
 		990FD296201B4A5F002A39A1 /* PHCachingImageManager+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PHCachingImageManager+Helpers.swift"; sourceTree = "<group>"; };
 		990FD298201B67FE002A39A1 /* PHFetchResult + IndexPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PHFetchResult + IndexPath.swift"; sourceTree = "<group>"; };
+		9911FA23203C3A31000E9B06 /* UIImage+ResetOrientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+ResetOrientation.swift"; sourceTree = "<group>"; };
 		99A052991F20A19B005600B3 /* YPAlbumVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPAlbumVC.swift; sourceTree = "<group>"; };
 		99A0529C1F20B45D005600B3 /* YPAlbumView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPAlbumView.swift; sourceTree = "<group>"; };
 		99A0529E1F20B480005600B3 /* YPAlbumCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPAlbumCell.swift; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 				99CF6D1A201B6A5C00487F77 /* UICollectionView+IndexPath.swift */,
 				99CF6D1C201B6ABA00487F77 /* IndexSet+IndexPath.swift */,
 				99CF6D1E201B6B9E00487F77 /* CGRect+Difference.swift */,
+				9911FA23203C3A31000E9B06 /* UIImage+ResetOrientation.swift */,
 				99CF6D26201B739600487F77 /* YPAlerts.swift */,
 			);
 			path = Helpers;
@@ -408,6 +411,7 @@
 				99019E532018CE19007325C2 /* YPPickerScreen.swift in Sources */,
 				99CF6D1F201B6B9E00487F77 /* CGRect+Difference.swift in Sources */,
 				99CF6D1D201B6ABA00487F77 /* IndexSet+IndexPath.swift in Sources */,
+				9911FA24203C3A31000E9B06 /* UIImage+ResetOrientation.swift in Sources */,
 				990FD291201B3CB4002A39A1 /* YPLibraryVC + UIHelpers.swift in Sources */,
 				99C6D6CE1F1FB5C100711DB2 /* YPPhotoSaver.swift in Sources */,
 				99C6D6C31F1FB5C100711DB2 /* YPCameraView.swift in Sources */,

--- a/YPImagePickerExample/YPImagePickerExample/ViewController.swift
+++ b/YPImagePickerExample/YPImagePickerExample/ViewController.swift
@@ -48,6 +48,7 @@ class ViewController: UIViewController {
         config.albumName = "MyGreatAppName"
         config.screens = [.library, .photo, .video] // customize screens and their order here.
         config.startOnScreen = .library
+        config.showsCrop = .rectangle(ratio: (16/9))
 //        config.videoRecordingTimeLimit = 10
 //        config.videoFromLibraryTimeLimit = 10
         

--- a/YPImagePickerExample/YPImagePickerExample/ViewController.swift
+++ b/YPImagePickerExample/YPImagePickerExample/ViewController.swift
@@ -37,20 +37,57 @@ class ViewController: UIViewController {
         
         // Configuration
         var config = YPImagePickerConfiguration()
-        config.onlySquareImagesFromLibrary = false
-        config.onlySquareImagesFromCamera = true
-//        config.libraryTargetImageSize = .original
-        config.showsVideoInLibrary = true //false
-//        config.usesFrontCamera = true // false
-//        config.showsFilters = true
-//        config.shouldSaveNewPicturesToAlbum = true
-        config.videoCompression = AVAssetExportPresetHighestQuality
-        config.albumName = "MyGreatAppName"
-        config.screens = [.library, .photo, .video] // customize screens and their order here.
-        config.startOnScreen = .library
+        
+        // Uncomment and play around with the configuration 👨‍🔬 🚀
+
+//        /// Set this to true if you want to force the  library output to be a squared image. Defaults to false
+//        config.onlySquareImagesFromLibrary = true
+//
+//        /// Set this to true if you want to force the camera output to be a squared image. Defaults to true
+//        config.onlySquareImagesFromCamera = false
+//
+//        /// Ex: cappedTo:1024 will make sure images from the library will be
+//        /// resized to fit in a 1024x1024 box. Defaults to original image size.
+//        config.libraryTargetImageSize = .cappedTo(size: 1024)
+//
+//        /// Enables videos within the library. Defaults to false
+        config.showsVideoInLibrary = true
+//
+//        /// Enables selecting the front camera by default, useful for avatars. Defaults to false
+//        config.usesFrontCamera = true
+//
+//        /// Adds a Filter step in the photo taking process.  Defaults to true
+        config.showsFilters = false
+//
+//        /// Enables you to opt out from saving new (or old but filtered) images to the
+//        /// user's photo library. Defaults to true.
+//        config.shouldSaveNewPicturesToAlbum = false
+//
+//        /// Choose the videoCompression.  Defaults to AVAssetExportPresetHighestQuality
+//        config.videoCompression = AVAssetExportPreset640x480
+//
+//        /// Defines the name of the album when saving pictures in the user's photo library.
+//        /// In general that would be your App name. Defaults to "DefaultYPImagePickerAlbumName"
+//        config.albumName = "ThisIsMyAlbum"
+//
+//        /// Defines which screen is shown at launch. Video mode will only work if `showsVideo = true`.
+//        /// Default value is `.photo`
+//        config.startOnScreen = .video
+//
+//        /// Defines which screens are shown at launch, and their order.
+//        /// Default value is `[.library, .photo]`
+        config.screens = [.library, .photo, .video]
+//
+//        /// Defines the time limit for recording videos.
+//        /// Default is 30 seconds.
+//        config.videoRecordingTimeLimit = 5.0
+//
+//        /// Defines the time limit for videos from the library.
+//        /// Defaults to 60 seconds.
+//        config.videoFromLibraryTimeLimit = 10.0
+//
+//        /// Adds a Crop step in the photo taking process, after filters.  Defaults to .none
         config.showsCrop = .rectangle(ratio: (16/9))
-//        config.videoRecordingTimeLimit = 10
-//        config.videoFromLibraryTimeLimit = 10
         
         // Set it the default conf for all Pickers
         //      YPImagePicker.setDefaultConfiguration(config)


### PR DESCRIPTION
⚠️ This is not ready for merge yet

@userdar We can discuss and refine the details of the crop feature here

At the moment, the api looks like this : 

`showsCrop` is` .none` by default and can be activated like this:

```swift
config.showsCrop = .rectangle(ratio: (16/9))
```

In a later version (not this one). The same api will support a circle crop 👍 
```swift
config.showsCrop = .circle
```

I think an enum with associated types is a cool way to keep the api as simple as possible here :)

I'd love to know your thoughts,