### PR TITLE
Implements iOS10 AVCapturePhotoOutput new api

### DIFF
--- a/Source/Camera/PostiOS10PhotoCapture.swift
+++ b/Source/Camera/PostiOS10PhotoCapture.swift
@@ -108,5 +108,12 @@ class PostiOS10PhotoCapture: NSObject, YPPhotoCapture, AVCapturePhotoCaptureDele
         guard let data = photo.fileDataRepresentation() else { return }
         block?(data)
     }
+    
+    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photoSampleBuffer: CMSampleBuffer?, previewPhoto previewPhotoSampleBuffer: CMSampleBuffer?, resolvedSettings: AVCaptureResolvedPhotoSettings, bracketSettings: AVCaptureBracketedStillImageSettings?, error: Error?) {
+        guard let buffer = photoSampleBuffer else { return }
+        if let data = AVCapturePhotoOutput.jpegPhotoDataRepresentation(forJPEGSampleBuffer: buffer, previewPhotoSampleBuffer: previewPhotoSampleBuffer) {
+            block?(data)
+        }
+    }
 }
 

--- a/Source/Camera/PostiOS10PhotoCapture.swift
+++ b/Source/Camera/PostiOS10PhotoCapture.swift
@@ -30,7 +30,6 @@ class PostiOS10PhotoCapture: NSObject, YPPhotoCapture, AVCapturePhotoCaptureDele
     
     // MARK: - Configuration
     
-    
     private func newSettings() -> AVCapturePhotoSettings {
         var settings = AVCapturePhotoSettings()
         
@@ -50,20 +49,14 @@ class PostiOS10PhotoCapture: NSObject, YPPhotoCapture, AVCapturePhotoCaptureDele
             case .auto:
                 if photoOutput.supportedFlashModes.contains(.auto) {
                     settings.flashMode = .auto
-                } else {
-                    print("NOPE")
                 }
             case .off:
                 if photoOutput.supportedFlashModes.contains(.off) {
                     settings.flashMode = .off
-                } else {
-                    print("NOPE")
                 }
             case .on:
                 if photoOutput.supportedFlashModes.contains(.on) {
                     settings.flashMode = .on
-                } else {
-                    print("NOPE")
                 }
             }
         }

--- a/Source/Camera/PostiOS10PhotoCapture.swift
+++ b/Source/Camera/PostiOS10PhotoCapture.swift
@@ -1,0 +1,150 @@
+//
+//  PostiOS10PhotoCapture.swift
+//  YPImagePicker
+//
+//  Created by Sacha DSO on 08/03/2018.
+//  Copyright © 2018 Yummypets. All rights reserved.
+//
+
+import UIKit
+import AVFoundation
+
+@available(iOS 10.0, *)
+class PostiOS10PhotoCapture: NSObject, YPPhotoCapture, AVCapturePhotoCaptureDelegate {
+    
+    private let photoOutput = AVCapturePhotoOutput()
+    var block: ((Data) -> Void)?
+    var currentFlashMode: YPFlashMode = .off
+    var previewView: UIView!
+    var isPreviewSetup: Bool = false
+    var videoLayer: AVCaptureVideoPreviewLayer!
+    
+    
+    var output: AVCaptureOutput { return photoOutput }
+    var deviceInput: AVCaptureDeviceInput!
+    var device: AVCaptureDevice? { return deviceInput.device }
+    let sessionQueue = DispatchQueue(label: "YPCameraVCSerialQueue", qos: .background)
+    let session = AVCaptureSession()
+    
+    var hasFlash: Bool {
+        guard let device = device else { return false }
+        return device.hasFlash
+    }
+    
+    func setup(with previewView: UIView) {
+        self.previewView = previewView
+        sessionQueue.async { [unowned self] in
+            self.setupCaptureSession()
+        }
+    }
+    
+    func focus(on point: CGPoint) {
+        setFocusPointOnDevice(device: device!, point: point)
+    }
+    
+    private func setupCaptureSession() {
+        session.beginConfiguration()
+        session.sessionPreset = .photo
+        let cameraPosition: AVCaptureDevice.Position = .back
+        
+        //TODO self.configuration.usesFrontCamera ? .front : .back
+        let aDevice = deviceForPosition(cameraPosition)
+        if let d = aDevice {
+            deviceInput = try? AVCaptureDeviceInput(device: d)
+        }
+        if let videoInput = deviceInput {
+            if session.canAddInput(videoInput) {
+                session.addInput(videoInput)
+            }
+            if session.canAddOutput(output) {
+                session.addOutput(output)
+                configure()
+            }
+        }
+        session.commitConfiguration()
+    }
+    
+    func tryToggleFlash() {
+        //        if device.hasFlash device.isFlashAvailable //TODO test these
+        switch currentFlashMode {
+        case .auto:
+            currentFlashMode = .on
+        case .on:
+            currentFlashMode = .off
+        case .off:
+            currentFlashMode = .auto
+        }
+    }
+    
+    private func newSettings() -> AVCapturePhotoSettings {
+        var settings = AVCapturePhotoSettings()
+        
+        // Catpure Heif when available.
+        if #available(iOS 11.0, *) {
+            if photoOutput.availablePhotoCodecTypes.contains(.hevc) {
+                settings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.hevc])
+            }
+        }
+        
+        // Catpure Highest Quality possible.
+        settings.isHighResolutionPhotoEnabled = true
+        
+        // Set flash mode.
+        if deviceInput.device.isFlashAvailable {
+            switch currentFlashMode {
+            case .auto:
+                if photoOutput.supportedFlashModes.contains(.auto) {
+                    settings.flashMode = .auto
+                } else {
+                    print("NOPE")
+                }
+            case .off:
+                if photoOutput.supportedFlashModes.contains(.off) {
+                    settings.flashMode = .off
+                } else {
+                    print("NOPE")
+                }
+            case .on:
+                if photoOutput.supportedFlashModes.contains(.on) {
+                    settings.flashMode = .on
+                } else {
+                    print("NOPE")
+                }
+            }
+        }
+        return settings
+    }
+
+    func shoot(completion: @escaping (Data) -> Void) {
+        block = completion
+    
+        // Set current device orientation
+        setCurrentOrienation()
+        
+        let settings = newSettings()
+        photoOutput.capturePhoto(with: settings, delegate: self)
+    }
+
+    func configure() {
+        photoOutput.isHighResolutionCaptureEnabled = true
+        
+        // Improve capture time by preparing output with the desired settings.
+        photoOutput.setPreparedPhotoSettingsArray([newSettings()], completionHandler: nil)
+    }
+
+    @available(iOS 11.0, *)
+    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        print("didFinishProcessingPhoto")
+        if let data = photo.fileDataRepresentation() {
+            
+            let bcf = ByteCountFormatter()
+            bcf.allowedUnits = [.useMB] // optional: restricts the units to MB only
+            bcf.countStyle = .file
+            let string = bcf.string(fromByteCount: Int64(data.count))
+            print("formatted result: \(string)")
+            
+            block?(data)
+        }
+    }
+}
+

--- a/Source/Camera/PostiOS10PhotoCapture.swift
+++ b/Source/Camera/PostiOS10PhotoCapture.swift
@@ -11,70 +11,25 @@ import AVFoundation
 
 @available(iOS 10.0, *)
 class PostiOS10PhotoCapture: NSObject, YPPhotoCapture, AVCapturePhotoCaptureDelegate {
-    
-    private let photoOutput = AVCapturePhotoOutput()
-    var block: ((Data) -> Void)?
-    var currentFlashMode: YPFlashMode = .off
-    var previewView: UIView!
-    var isPreviewSetup: Bool = false
-    var videoLayer: AVCaptureVideoPreviewLayer!
-    
-    
-    var output: AVCaptureOutput { return photoOutput }
-    var deviceInput: AVCaptureDeviceInput!
-    var device: AVCaptureDevice? { return deviceInput.device }
+
     let sessionQueue = DispatchQueue(label: "YPCameraVCSerialQueue", qos: .background)
     let session = AVCaptureSession()
-    
+    var deviceInput: AVCaptureDeviceInput!
+    var device: AVCaptureDevice? { return deviceInput.device }
+    private let photoOutput = AVCapturePhotoOutput()
+    var output: AVCaptureOutput { return photoOutput }
+    var isPreviewSetup: Bool = false
+    var previewView: UIView!
+    var videoLayer: AVCaptureVideoPreviewLayer!
+    var currentFlashMode: YPFlashMode = .off
     var hasFlash: Bool {
         guard let device = device else { return false }
         return device.hasFlash
     }
+    var block: ((Data) -> Void)?
     
-    func setup(with previewView: UIView) {
-        self.previewView = previewView
-        sessionQueue.async { [unowned self] in
-            self.setupCaptureSession()
-        }
-    }
+    // MARK: - Configuration
     
-    func focus(on point: CGPoint) {
-        setFocusPointOnDevice(device: device!, point: point)
-    }
-    
-    private func setupCaptureSession() {
-        session.beginConfiguration()
-        session.sessionPreset = .photo
-        let cameraPosition: AVCaptureDevice.Position = .back
-        
-        //TODO self.configuration.usesFrontCamera ? .front : .back
-        let aDevice = deviceForPosition(cameraPosition)
-        if let d = aDevice {
-            deviceInput = try? AVCaptureDeviceInput(device: d)
-        }
-        if let videoInput = deviceInput {
-            if session.canAddInput(videoInput) {
-                session.addInput(videoInput)
-            }
-            if session.canAddOutput(output) {
-                session.addOutput(output)
-                configure()
-            }
-        }
-        session.commitConfiguration()
-    }
-    
-    func tryToggleFlash() {
-        //        if device.hasFlash device.isFlashAvailable //TODO test these
-        switch currentFlashMode {
-        case .auto:
-            currentFlashMode = .on
-        case .on:
-            currentFlashMode = .off
-        case .off:
-            currentFlashMode = .auto
-        }
-    }
     
     private func newSettings() -> AVCapturePhotoSettings {
         var settings = AVCapturePhotoSettings()
@@ -114,6 +69,29 @@ class PostiOS10PhotoCapture: NSObject, YPPhotoCapture, AVCapturePhotoCaptureDele
         }
         return settings
     }
+    
+    func configure() {
+        photoOutput.isHighResolutionCaptureEnabled = true
+        
+        // Improve capture time by preparing output with the desired settings.
+        photoOutput.setPreparedPhotoSettingsArray([newSettings()], completionHandler: nil)
+    }
+    
+    // MARK: - Flash
+    
+    func tryToggleFlash() {
+        //        if device.hasFlash device.isFlashAvailable //TODO test these
+        switch currentFlashMode {
+        case .auto:
+            currentFlashMode = .on
+        case .on:
+            currentFlashMode = .off
+        case .off:
+            currentFlashMode = .auto
+        }
+    }
+    
+    // MARK: - Shoot
 
     func shoot(completion: @escaping (Data) -> Void) {
         block = completion
@@ -125,26 +103,10 @@ class PostiOS10PhotoCapture: NSObject, YPPhotoCapture, AVCapturePhotoCaptureDele
         photoOutput.capturePhoto(with: settings, delegate: self)
     }
 
-    func configure() {
-        photoOutput.isHighResolutionCaptureEnabled = true
-        
-        // Improve capture time by preparing output with the desired settings.
-        photoOutput.setPreparedPhotoSettingsArray([newSettings()], completionHandler: nil)
-    }
-
     @available(iOS 11.0, *)
     func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
-        print("didFinishProcessingPhoto")
-        if let data = photo.fileDataRepresentation() {
-            
-            let bcf = ByteCountFormatter()
-            bcf.allowedUnits = [.useMB] // optional: restricts the units to MB only
-            bcf.countStyle = .file
-            let string = bcf.string(fromByteCount: Int64(data.count))
-            print("formatted result: \(string)")
-            
-            block?(data)
-        }
+        guard let data = photo.fileDataRepresentation() else { return }
+        block?(data)
     }
 }
 

--- a/Source/Camera/PostiOS10PhotoCapture.swift
+++ b/Source/Camera/PostiOS10PhotoCapture.swift
@@ -14,8 +14,8 @@ class PostiOS10PhotoCapture: NSObject, YPPhotoCapture, AVCapturePhotoCaptureDele
 
     let sessionQueue = DispatchQueue(label: "YPCameraVCSerialQueue", qos: .background)
     let session = AVCaptureSession()
-    var deviceInput: AVCaptureDeviceInput!
-    var device: AVCaptureDevice? { return deviceInput.device }
+    var deviceInput: AVCaptureDeviceInput?
+    var device: AVCaptureDevice? { return deviceInput?.device }
     private let photoOutput = AVCapturePhotoOutput()
     var output: AVCaptureOutput { return photoOutput }
     var isPreviewSetup: Bool = false
@@ -44,19 +44,21 @@ class PostiOS10PhotoCapture: NSObject, YPPhotoCapture, AVCapturePhotoCaptureDele
         settings.isHighResolutionPhotoEnabled = true
         
         // Set flash mode.
-        if deviceInput.device.isFlashAvailable {
-            switch currentFlashMode {
-            case .auto:
-                if photoOutput.supportedFlashModes.contains(.auto) {
-                    settings.flashMode = .auto
-                }
-            case .off:
-                if photoOutput.supportedFlashModes.contains(.off) {
-                    settings.flashMode = .off
-                }
-            case .on:
-                if photoOutput.supportedFlashModes.contains(.on) {
-                    settings.flashMode = .on
+        if let deviceInput = deviceInput {
+            if deviceInput.device.isFlashAvailable {
+                switch currentFlashMode {
+                case .auto:
+                    if photoOutput.supportedFlashModes.contains(.auto) {
+                        settings.flashMode = .auto
+                    }
+                case .off:
+                    if photoOutput.supportedFlashModes.contains(.off) {
+                        settings.flashMode = .off
+                    }
+                case .on:
+                    if photoOutput.supportedFlashModes.contains(.on) {
+                        settings.flashMode = .on
+                    }
                 }
             }
         }

--- a/Source/Camera/PreiOS10PhotoCapture.swift
+++ b/Source/Camera/PreiOS10PhotoCapture.swift
@@ -1,0 +1,98 @@
+//
+//  PreiOS10PhotoCapture.swift
+//  YPImagePicker
+//
+//  Created by Sacha DSO on 08/03/2018.
+//  Copyright © 2018 Yummypets. All rights reserved.
+//
+
+import Foundation
+import AVFoundation
+import UIKit
+
+class PreiOS10PhotoCapture: YPPhotoCapture {
+    
+    var videoLayer: AVCaptureVideoPreviewLayer!
+    var previewView: UIView!
+    var isPreviewSetup: Bool = false
+    var currentFlashMode: YPFlashMode = .off
+
+    let imageOutput = AVCaptureStillImageOutput()
+    
+    var output: AVCaptureOutput { return imageOutput }
+    var deviceInput: AVCaptureDeviceInput!
+    var device: AVCaptureDevice? { return deviceInput.device }
+    let sessionQueue = DispatchQueue(label: "YPCameraVCSerialQueue", qos: .background)
+    let session = AVCaptureSession()
+    
+    var hasFlash: Bool {
+        guard let device = device else { return false }
+        return device.hasFlash
+    }
+    
+    func setup(with previewView: UIView) {
+        self.previewView = previewView
+        sessionQueue.async { [unowned self] in
+            self.setupCaptureSession()
+        }
+    }
+    
+    private func setupCaptureSession() {
+        session.beginConfiguration()
+        session.sessionPreset = .photo
+        let cameraPosition: AVCaptureDevice.Position = .back
+            
+            //TODO self.configuration.usesFrontCamera ? .front : .back
+        let aDevice = deviceForPosition(cameraPosition)
+        if let d = aDevice {
+            deviceInput = try? AVCaptureDeviceInput(device: d)
+        }
+        if let videoInput = deviceInput {
+            if session.canAddInput(videoInput) {
+                session.addInput(videoInput)
+            }
+            if session.canAddOutput(output) {
+                session.addOutput(output)
+//                configure()
+            }
+        }
+        session.commitConfiguration()
+    }
+    
+    func focus(on point: CGPoint) {
+        setFocusPointOnDevice(device: device!, point: point)
+    }
+    
+    func shoot(completion: @escaping (Data) -> Void) {
+        DispatchQueue.global(qos: .default).async {
+            self.setCurrentOrienation()
+            if let connection = self.output.connection(with: .video) {
+                self.imageOutput.captureStillImageAsynchronously(from: connection) { buffer, _ in
+                    if let data = AVCaptureStillImageOutput.jpegStillImageNSDataRepresentation(buffer!) {
+                        completion(data)
+                    }
+                }
+            }
+        }
+    }
+    
+    func tryToggleFlash() {
+        guard let device = device else { return }
+        guard device.hasFlash else { return }
+        do {
+            try device.lockForConfiguration()
+            switch device.flashMode {
+            case .auto:
+                currentFlashMode = .on
+                device.flashMode = .on
+            case .on:
+                currentFlashMode = .off
+                device.flashMode = .off
+            case .off:
+                currentFlashMode = .auto
+                device.flashMode = .auto
+            }
+            device.unlockForConfiguration()
+        } catch _ { }
+    }
+}

--- a/Source/Camera/PreiOS10PhotoCapture.swift
+++ b/Source/Camera/PreiOS10PhotoCapture.swift
@@ -11,70 +11,27 @@ import AVFoundation
 import UIKit
 
 class PreiOS10PhotoCapture: YPPhotoCapture {
-    
-    var videoLayer: AVCaptureVideoPreviewLayer!
-    var previewView: UIView!
-    var isPreviewSetup: Bool = false
-    var currentFlashMode: YPFlashMode = .off
 
-    let imageOutput = AVCaptureStillImageOutput()
-    
-    var output: AVCaptureOutput { return imageOutput }
-    var deviceInput: AVCaptureDeviceInput!
-    var device: AVCaptureDevice? { return deviceInput.device }
     let sessionQueue = DispatchQueue(label: "YPCameraVCSerialQueue", qos: .background)
     let session = AVCaptureSession()
-    
+    var deviceInput: AVCaptureDeviceInput!
+    var device: AVCaptureDevice? { return deviceInput.device }
+    private let imageOutput = AVCaptureStillImageOutput()
+    var output: AVCaptureOutput { return imageOutput }
+    var isPreviewSetup: Bool = false
+    var previewView: UIView!
+    var videoLayer: AVCaptureVideoPreviewLayer!
+    var currentFlashMode: YPFlashMode = .off
     var hasFlash: Bool {
         guard let device = device else { return false }
         return device.hasFlash
     }
     
-    func setup(with previewView: UIView) {
-        self.previewView = previewView
-        sessionQueue.async { [unowned self] in
-            self.setupCaptureSession()
-        }
-    }
+    // MARK: - Configuration
     
-    private func setupCaptureSession() {
-        session.beginConfiguration()
-        session.sessionPreset = .photo
-        let cameraPosition: AVCaptureDevice.Position = .back
-            
-            //TODO self.configuration.usesFrontCamera ? .front : .back
-        let aDevice = deviceForPosition(cameraPosition)
-        if let d = aDevice {
-            deviceInput = try? AVCaptureDeviceInput(device: d)
-        }
-        if let videoInput = deviceInput {
-            if session.canAddInput(videoInput) {
-                session.addInput(videoInput)
-            }
-            if session.canAddOutput(output) {
-                session.addOutput(output)
-//                configure()
-            }
-        }
-        session.commitConfiguration()
-    }
+    func configure() { }
     
-    func focus(on point: CGPoint) {
-        setFocusPointOnDevice(device: device!, point: point)
-    }
-    
-    func shoot(completion: @escaping (Data) -> Void) {
-        DispatchQueue.global(qos: .default).async {
-            self.setCurrentOrienation()
-            if let connection = self.output.connection(with: .video) {
-                self.imageOutput.captureStillImageAsynchronously(from: connection) { buffer, _ in
-                    if let data = AVCaptureStillImageOutput.jpegStillImageNSDataRepresentation(buffer!) {
-                        completion(data)
-                    }
-                }
-            }
-        }
-    }
+    // MARK: - Flash
     
     func tryToggleFlash() {
         guard let device = device else { return }
@@ -94,5 +51,20 @@ class PreiOS10PhotoCapture: YPPhotoCapture {
             }
             device.unlockForConfiguration()
         } catch _ { }
+    }
+    
+    // MARK: - Shoot
+    
+    func shoot(completion: @escaping (Data) -> Void) {
+        DispatchQueue.global(qos: .default).async {
+            self.setCurrentOrienation()
+            if let connection = self.output.connection(with: .video) {
+                self.imageOutput.captureStillImageAsynchronously(from: connection) { buffer, _ in
+                    if let data = AVCaptureStillImageOutput.jpegStillImageNSDataRepresentation(buffer!) {
+                        completion(data)
+                    }
+                }
+            }
+        }
     }
 }

--- a/Source/Camera/PreiOS10PhotoCapture.swift
+++ b/Source/Camera/PreiOS10PhotoCapture.swift
@@ -14,8 +14,8 @@ class PreiOS10PhotoCapture: YPPhotoCapture {
 
     let sessionQueue = DispatchQueue(label: "YPCameraVCSerialQueue", qos: .background)
     let session = AVCaptureSession()
-    var deviceInput: AVCaptureDeviceInput!
-    var device: AVCaptureDevice? { return deviceInput.device }
+    var deviceInput: AVCaptureDeviceInput?
+    var device: AVCaptureDevice? { return deviceInput?.device }
     private let imageOutput = AVCaptureStillImageOutput()
     var output: AVCaptureOutput { return imageOutput }
     var isPreviewSetup: Bool = false

--- a/Source/Camera/YPCameraVC.swift
+++ b/Source/Camera/YPCameraVC.swift
@@ -117,7 +117,7 @@ public class YPCameraVC: UIViewController, UIGestureRecognizerDelegate, Permissi
                 return
             }
             
-        self.photoCapture.stopCamera()
+            self.photoCapture.stopCamera()
             
             var image = shotImage
             // Crop the image if the output needs to be square.
@@ -186,4 +186,3 @@ public class YPCameraVC: UIViewController, UIGestureRecognizerDelegate, Permissi
         v.flashButton.isHidden = !photoCapture.hasFlash
     }
 }
-

--- a/Source/Camera/YPCameraVC.swift
+++ b/Source/Camera/YPCameraVC.swift
@@ -13,15 +13,7 @@ import Photos
 public class YPCameraVC: UIViewController, UIGestureRecognizerDelegate, PermissionCheckable {
     
     public var didCapturePhoto: ((UIImage) -> Void)?
-    private let sessionQueue = DispatchQueue(label: "YPCameraVCSerialQueue", qos: .background)
-    let session = AVCaptureSession()
-    var device: AVCaptureDevice? {
-        return videoInput?.device
-    }
-    var videoInput: AVCaptureDeviceInput!
-    let imageOutput = AVCaptureStillImageOutput()
-    var isPreviewSetup = false
-    
+    let photoCapture = newPhotoCapture()
     let v: YPCameraView!
     override public func loadView() { view = v }
 
@@ -44,60 +36,24 @@ public class YPCameraVC: UIViewController, UIGestureRecognizerDelegate, Permissi
         v.flashButton.addTarget(self, action: #selector(flashButtonTapped), for: .touchUpInside)
         v.shotButton.addTarget(self, action: #selector(shotButtonTapped), for: .touchUpInside)
         v.flipButton.addTarget(self, action: #selector(flipButtonTapped), for: .touchUpInside)
-        sessionQueue.async { [unowned self] in
-            self.setupCaptureSession()
-        }
+        
+        photoCapture.setup(with: v.previewViewContainer)
+        
+        // Focus
+        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.focusTapped(_:)))
+        tapRecognizer.delegate = self
+        v.previewViewContainer.addGestureRecognizer(tapRecognizer)
+        
     }
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if isPreviewSetup {
-            startCamera()
-        }
+        photoCapture.tryToStartCamera()
     }
     
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         refreshFlashButton()
-    }
-    
-    func tryToSetupPreview() {
-        if !isPreviewSetup {
-            setupPreview()
-            isPreviewSetup = true
-        }
-    }
-    
-    func setupPreview() {
-        let videoLayer = AVCaptureVideoPreviewLayer(session: session)
-        
-        DispatchQueue.main.async {
-            videoLayer.frame = self.v.previewViewContainer.bounds
-            videoLayer.videoGravity = AVLayerVideoGravity.resizeAspectFill
-            self.v.previewViewContainer.layer.addSublayer(videoLayer)
-            let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.focusTapped(_:)))
-            tapRecognizer.delegate = self
-            self.v.previewViewContainer.addGestureRecognizer(tapRecognizer)
-        }
-    }
-    
-    private func setupCaptureSession() {
-        session.beginConfiguration()
-        session.sessionPreset = AVCaptureSession.Preset.photo
-        let cameraPosition: AVCaptureDevice.Position = self.configuration.usesFrontCamera ? .front : .back
-        let aDevice = deviceForPosition(cameraPosition)
-        if let d = aDevice {
-            videoInput = try? AVCaptureDeviceInput(device: d)
-        }
-        if let videoInput = videoInput {
-            if session.canAddInput(videoInput) {
-                session.addInput(videoInput)
-            }
-            if session.canAddOutput(imageOutput) {
-                session.addOutput(imageOutput)
-            }
-        }
-        session.commitConfiguration()
     }
     
     @objc
@@ -108,10 +64,15 @@ public class YPCameraVC: UIViewController, UIGestureRecognizerDelegate, Permissi
     }
     
     func focus(recognizer: UITapGestureRecognizer) {
+
         let point = recognizer.location(in: v.previewViewContainer)
+        
+        // Focus the capture
         let viewsize = v.previewViewContainer.bounds.size
         let newPoint = CGPoint(x: point.x/viewsize.width, y: point.y/viewsize.height)
-        setFocusPointOnDevice(device: device!, point: newPoint)
+        photoCapture.focus(on: newPoint)
+        
+        // Animate focus view
         v.focusView.center = point
         configureFocusView(v.focusView)
         v.addSubview(v.focusView)
@@ -120,59 +81,24 @@ public class YPCameraVC: UIViewController, UIGestureRecognizerDelegate, Permissi
     
     public func tryToStartCamera() {
         doAfterPermissionCheck { [weak self] in
-            self?.startCamera()
-        }
-    }
-    
-    private func startCamera() {
-        if !session.isRunning {
-            sessionQueue.async { [unowned self] in
-                // Re-apply session preset
-                self.session.sessionPreset = AVCaptureSession.Preset.photo
-                let status = AVCaptureDevice.authorizationStatus(for: AVMediaType.video)
-                switch status {
-                case .notDetermined, .restricted, .denied:
-                    self.session.stopRunning()
-                case .authorized:
-                    self.session.startRunning()
-                    self.tryToSetupPreview()
-                }
-            }
+            self?.photoCapture.startCamera()
         }
     }
     
     func stopCamera() {
-        if session.isRunning {
-            sessionQueue.async { [weak self] in
-                self?.session.stopRunning()
-            }
-        }
+        photoCapture.stopCamera()
     }
     
     @objc
     func flipButtonTapped() {
         doAfterPermissionCheck { [weak self] in
-            self?.flip()
+            self?.photoCapture.flipCamera()
+            DispatchQueue.main.async {
+                self?.refreshFlashButton()
+            }
         }
     }
     
-    func flip() {
-        sessionQueue.async { [weak self] in
-            self?.flipCamera()
-        }
-    }
-    
-    private func flipCamera() {
-        session.resetInputs()
-        videoInput = flippedDeviceInputForInput(videoInput)
-        if session.canAddInput(videoInput) {
-            session.addInput(videoInput)
-        }
-        DispatchQueue.main.async {
-            self.refreshFlashButton()
-        }
-    }
-
     @objc
     func shotButtonTapped() {
         doAfterPermissionCheck { [weak self] in
@@ -185,42 +111,28 @@ public class YPCameraVC: UIViewController, UIGestureRecognizerDelegate, Permissi
         // causing a crash
         v.shotButton.isEnabled = false
         
-        DispatchQueue.global(qos: .default).async {
-            let videoConnection = self.imageOutput.connection(with: AVMediaType.video)
-            let orientation: UIDeviceOrientation = UIDevice.current.orientation
-            switch orientation {
-            case .portrait:
-                videoConnection?.videoOrientation = .portrait
-            case .portraitUpsideDown:
-                videoConnection?.videoOrientation = .portraitUpsideDown
-            case .landscapeRight:
-                videoConnection?.videoOrientation = .landscapeLeft
-            case .landscapeLeft:
-                videoConnection?.videoOrientation = .landscapeRight
-            default:
-                videoConnection?.videoOrientation = .portrait
+        photoCapture.shoot { imageData in
+            
+            guard let shotImage = UIImage(data: imageData) else {
+                return
             }
             
-            self.imageOutput.captureStillImageAsynchronously(from: videoConnection!) { buffer, _ in
-                self.session.stopRunning()
-                let data = AVCaptureStillImageOutput.jpegStillImageNSDataRepresentation(buffer!)
-                if var image = UIImage(data: data!) {
-                    
-                    // Crop the image if the output needs to be square.
-                    if self.configuration.onlySquareImagesFromCamera {
-                        image = self.cropImageToSquare(image)
-                    }
-                    
-                    // Flip image if taken form the front camera.
-                    if let device = self.device, device.position == .front {
-                        image = self.flipImage(image: image)
-                    }
-                    
-                    DispatchQueue.main.async {
-                        let noOrietationImage = image.resetOrientation()
-                        self.didCapturePhoto?(noOrietationImage)
-                    }
-                }
+        self.photoCapture.stopCamera()
+            
+            var image = shotImage
+            // Crop the image if the output needs to be square.
+            if self.configuration.onlySquareImagesFromCamera {
+                image = self.cropImageToSquare(image)
+            }
+
+            // Flip image if taken form the front camera.
+            if let device = self.photoCapture.device, device.position == .front {
+                image = self.flipImage(image: image)
+            }
+            
+            DispatchQueue.main.async {
+                let noOrietationImage = image.resetOrientation()
+                self.didCapturePhoto?(noOrietationImage)
             }
         }
     }
@@ -264,22 +176,14 @@ public class YPCameraVC: UIViewController, UIGestureRecognizerDelegate, Permissi
     
     @objc
     func flashButtonTapped() {
-        device?.tryToggleFlash()
+        photoCapture.tryToggleFlash()
         refreshFlashButton()
     }
     
     func refreshFlashButton() {
-        if let device = device {
-            v.flashButton.setImage(flashImage(forAVCaptureFlashMode: device.flashMode), for: .normal)
-            v.flashButton.isHidden = !device.hasFlash
-        }
-    }
-
-    func flashImage(forAVCaptureFlashMode: AVCaptureDevice.FlashMode) -> UIImage {
-        switch forAVCaptureFlashMode {
-        case .on: return flashOnImage!
-        case .off: return flashOffImage!
-        case .auto: return flashAutoImage!
-        }
+        let flashImage = photoCapture.currentFlashMode.flashImage()
+        v.flashButton.setImage(flashImage, for: .normal)
+        v.flashButton.isHidden = !photoCapture.hasFlash
     }
 }
+

--- a/Source/Camera/YPCameraView.swift
+++ b/Source/Camera/YPCameraView.swift
@@ -20,21 +20,36 @@ class YPCameraView: UIView, UIGestureRecognizerDelegate {
     let timeElapsedLabel = UILabel()
     let progressBar = UIProgressView()
 
-    convenience init(overlayView: UIView) {
+    convenience init(overlayView: UIView? = nil) {
         self.init(frame: .zero)
         
-        // View Hierarchy
-        sv(
-            previewViewContainer,
-            overlayView,
-            progressBar,
-            timeElapsedLabel,
-            flashButton,
-            flipButton,
-            buttonsContainer.sv(
-                shotButton
+        
+        if let overlayView = overlayView {
+            // View Hierarchy
+            sv(
+                previewViewContainer,
+                overlayView,
+                progressBar,
+                timeElapsedLabel,
+                flashButton,
+                flipButton,
+                buttonsContainer.sv(
+                    shotButton
+                )
             )
-        )
+        } else {
+            // View Hierarchy
+            sv(
+                previewViewContainer,
+                progressBar,
+                timeElapsedLabel,
+                flashButton,
+                flipButton,
+                buttonsContainer.sv(
+                    shotButton
+                )
+            )
+        }
         
         // Layout
         let isIphone4 = UIScreen.main.bounds.height == 480
@@ -50,7 +65,7 @@ class YPCameraView: UIView, UIGestureRecognizerDelegate {
         )
         previewViewContainer.heightEqualsWidth()
 
-        overlayView.followEdges(previewViewContainer)
+        overlayView?.followEdges(previewViewContainer)
 
         |-(15+sideMargin)-flashButton.size(42)
         flashButton.Bottom == previewViewContainer.Bottom - 15

--- a/Source/Camera/YPPhotoCapture.swift
+++ b/Source/Camera/YPPhotoCapture.swift
@@ -13,27 +13,28 @@ import UIKit
 protocol YPPhotoCapture: class {
     
     // Public api
-    func setup(with previewView: UIView) // try setup with previewView.
+    func setup(with previewView: UIView)
     func tryToStartCamera()
     func stopCamera()
     func focus(on point: CGPoint)
     func tryToggleFlash()
     var hasFlash: Bool { get }
-    var currentFlashMode: YPFlashMode { get } // putno flash in falshmode.
+    var currentFlashMode: YPFlashMode { get }
     func flipCamera()
     func shoot(completion: @escaping (Data) -> Void)
     var videoLayer: AVCaptureVideoPreviewLayer! { get set }
+    var device: AVCaptureDevice? { get }
     
     
-    // Used in Default extension
-    var previewView: UIView! { get }
+    // Used by Default extension
+    var previewView: UIView! { get set }
     func startCamera()
     var isPreviewSetup: Bool { get set }
     var sessionQueue: DispatchQueue { get }
     var session: AVCaptureSession { get }
     var output: AVCaptureOutput { get }
     var deviceInput: AVCaptureDeviceInput! { get set }
-    var device: AVCaptureDevice? { get } // not needed
+    func configure()
 }
 
 func newPhotoCapture() -> YPPhotoCapture {

--- a/Source/Camera/YPPhotoCapture.swift
+++ b/Source/Camera/YPPhotoCapture.swift
@@ -1,0 +1,62 @@
+//
+//  YPPhotoCapture.swift
+//  YPImagePicker
+//
+//  Created by Sacha DSO on 08/03/2018.
+//  Copyright © 2018 Yummypets. All rights reserved.
+//
+
+import Foundation
+import AVFoundation
+import UIKit
+
+protocol YPPhotoCapture: class {
+    
+    // Public api
+    func setup(with previewView: UIView) // try setup with previewView.
+    func tryToStartCamera()
+    func stopCamera()
+    func focus(on point: CGPoint)
+    func tryToggleFlash()
+    var hasFlash: Bool { get }
+    var currentFlashMode: YPFlashMode { get } // putno flash in falshmode.
+    func flipCamera()
+    func shoot(completion: @escaping (Data) -> Void)
+    var videoLayer: AVCaptureVideoPreviewLayer! { get set }
+    
+    
+    // Used in Default extension
+    var previewView: UIView! { get }
+    func startCamera()
+    var isPreviewSetup: Bool { get set }
+    var sessionQueue: DispatchQueue { get }
+    var session: AVCaptureSession { get }
+    var output: AVCaptureOutput { get }
+    var deviceInput: AVCaptureDeviceInput! { get set }
+    var device: AVCaptureDevice? { get } // not needed
+}
+
+func newPhotoCapture() -> YPPhotoCapture {
+    if #available(iOS 10.0, *) {
+        return PostiOS10PhotoCapture()
+    } else {
+        return PreiOS10PhotoCapture()
+    }
+}
+
+enum YPFlashMode {
+    case off
+    case on
+    case auto
+}
+
+extension YPFlashMode {
+    func flashImage() -> UIImage {
+        switch self {
+        case .on: return flashOnImage!
+        case .off: return flashOffImage!
+        case .auto: return flashAutoImage!
+        }
+    }
+}
+

--- a/Source/Camera/YPPhotoCapture.swift
+++ b/Source/Camera/YPPhotoCapture.swift
@@ -33,7 +33,7 @@ protocol YPPhotoCapture: class {
     var sessionQueue: DispatchQueue { get }
     var session: AVCaptureSession { get }
     var output: AVCaptureOutput { get }
-    var deviceInput: AVCaptureDeviceInput! { get set }
+    var deviceInput: AVCaptureDeviceInput? { get set }
     func configure()
 }
 

--- a/Source/Camera/YPPhotoCaptureDefaults.swift
+++ b/Source/Camera/YPPhotoCaptureDefaults.swift
@@ -1,0 +1,91 @@
+//
+//  YPPhotoCaptureDefaults.swift
+//  YPImagePicker
+//
+//  Created by Sacha DSO on 08/03/2018.
+//  Copyright © 2018 Yummypets. All rights reserved.
+//
+
+import UIKit
+import AVFoundation
+
+extension YPPhotoCapture {
+    
+    func tryToStartCamera() {
+        if isPreviewSetup {
+            startCamera()
+        }
+    }
+    
+    func startCamera() {
+        if !session.isRunning {
+            sessionQueue.async { [unowned self] in
+                // Re-apply session preset
+                self.session.sessionPreset = .photo
+                let status = AVCaptureDevice.authorizationStatus(for: AVMediaType.video)
+                switch status {
+                case .notDetermined, .restricted, .denied:
+                    self.session.stopRunning()
+                case .authorized:
+                    self.session.startRunning()
+                    self.tryToSetupPreview()
+                }
+            }
+        }
+    }
+    
+    func tryToSetupPreview() {
+        if !isPreviewSetup {
+            setupPreview()
+            isPreviewSetup = true
+        }
+    }
+    
+    func setupPreview() {
+        videoLayer = AVCaptureVideoPreviewLayer(session: session)
+        DispatchQueue.main.async {
+            self.videoLayer.frame = self.previewView.bounds
+            self.videoLayer.videoGravity = AVLayerVideoGravity.resizeAspectFill
+            self.previewView.layer.addSublayer(self.videoLayer)
+        }
+    }
+    
+    func stopCamera() {
+        if session.isRunning {
+            sessionQueue.async { [weak self] in
+                self?.session.stopRunning()
+            }
+        }
+    }
+    
+    func flipCamera() {
+        sessionQueue.async { [weak self] in
+            self?.pflipCamera()
+        }
+    }
+    
+    private func pflipCamera() {
+        session.resetInputs()
+        deviceInput = flippedDeviceInputForInput(deviceInput)
+        if session.canAddInput(deviceInput) {
+            session.addInput(deviceInput)
+        }
+    }
+    
+    func setCurrentOrienation() {
+        let connection = output.connection(with: .video)
+        let orientation = UIDevice.current.orientation
+        switch orientation {
+        case .portrait:
+            connection?.videoOrientation = .portrait
+        case .portraitUpsideDown:
+            connection?.videoOrientation = .portraitUpsideDown
+        case .landscapeRight:
+            connection?.videoOrientation = .landscapeLeft
+        case .landscapeLeft:
+            connection?.videoOrientation = .landscapeRight
+        default:
+            connection?.videoOrientation = .portrait
+        }
+    }
+}

--- a/Source/Camera/YPPhotoCaptureDefaults.swift
+++ b/Source/Camera/YPPhotoCaptureDefaults.swift
@@ -109,7 +109,9 @@ extension YPPhotoCapture {
     
     private func flip() {
         session.resetInputs()
-        deviceInput = flippedDeviceInputForInput(deviceInput)
+        guard let di = deviceInput else { return }
+        deviceInput = flippedDeviceInputForInput(di)
+        guard let deviceInput = deviceInput else { return }
         if session.canAddInput(deviceInput) {
             session.addInput(deviceInput)
         }

--- a/Source/Helpers/YPHelpers.swift
+++ b/Source/Helpers/YPHelpers.swift
@@ -30,22 +30,22 @@ func deviceForPosition(_ p: AVCaptureDevice.Position) -> AVCaptureDevice? {
 }
 
 extension AVCaptureDevice {
-    func tryToggleFlash() {
-        guard hasFlash else { return }
-        do {
-            try lockForConfiguration()
-            switch flashMode {
-            case .auto:
-                flashMode = .on
-            case .on:
-                flashMode = .off
-            case .off:
-                flashMode = .auto
-            }
-            unlockForConfiguration()
-        } catch _ { }
-    }
-    
+//    func tryToggleFlash() {
+//        guard hasFlash else { return }
+//        do {
+//            try lockForConfiguration()
+//            switch flashMode {
+//            case .auto:
+//                flashMode = .on
+//            case .on:
+//                flashMode = .off
+//            case .off:
+//                flashMode = .auto
+//            }
+//            unlockForConfiguration()
+//        } catch _ { }
+//    }
+//    
     func tryToggleTorch() {
         guard hasFlash else { return }
         do {

--- a/Source/Video/YPVideoHelper.swift
+++ b/Source/Video/YPVideoHelper.swift
@@ -39,7 +39,7 @@ class YPVideoHelper: NSObject {
         if !session.isRunning {
             sessionQueue.async { [unowned self] in
                 // Re-apply session preset
-                self.session.sessionPreset = AVCaptureSession.Preset.high
+                self.session.sessionPreset = .high
                 let status = AVCaptureDevice.authorizationStatus(for: AVMediaType.video)
                 switch status {
                 case .notDetermined, .restricted, .denied:
@@ -164,7 +164,7 @@ class YPVideoHelper: NSObject {
             if session.canAddOutput(videoOutput) {
                 session.addOutput(videoOutput)
             }
-            session.sessionPreset = AVCaptureSession.Preset.high
+            session.sessionPreset = .high
         }
         session.commitConfiguration()
     }

--- a/Source/Video/YPVideoVC.swift
+++ b/Source/Video/YPVideoVC.swift
@@ -13,7 +13,7 @@ public class YPVideoVC: UIViewController, PermissionCheckable {
     public var didCaptureVideo: ((URL) -> Void)?
     
     private let videoHelper = YPVideoHelper()
-    private let v = YPCameraView()
+    private let v = YPCameraView(overlayView: nil)
     private var isPreviewSetup = false
     let configuration: YPImagePickerConfiguration!
     private var viewState = ViewState()

--- a/YPImagePicker.xcodeproj/project.pbxproj
+++ b/YPImagePicker.xcodeproj/project.pbxproj
@@ -20,7 +20,11 @@
 		990FD299201B67FE002A39A1 /* PHFetchResult + IndexPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990FD298201B67FE002A39A1 /* PHFetchResult + IndexPath.swift */; };
 		9911FA24203C3A31000E9B06 /* UIImage+ResetOrientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9911FA23203C3A31000E9B06 /* UIImage+ResetOrientation.swift */; };
 		99472DED2056E33700419F9E /* YPWordings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99472DEC2056E33700419F9E /* YPWordings.swift */; };
-		99472DEF2056E55B00419F9E /* YPPermissionDeniedPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99472DEE2056E55B00419F9E /* YPPermissionDeniedPopup.swift */; };
+		99278DA820512BD90059532E /* PreiOS10PhotoCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99278DA720512BD90059532E /* PreiOS10PhotoCapture.swift */; };
+		99278DAA20512BFB0059532E /* PostiOS10PhotoCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99278DA920512BFB0059532E /* PostiOS10PhotoCapture.swift */; };
+		99278DAC20512C330059532E /* YPPhotoCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99278DAB20512C330059532E /* YPPhotoCapture.swift */; };
+		99278DAE205140F60059532E /* YPPermissionDeniedPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99278DAD205140F60059532E /* YPPermissionDeniedPopup.swift */; };
+		99278DB02051816F0059532E /* YPPhotoCaptureDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99278DAF2051816F0059532E /* YPPhotoCaptureDefaults.swift */; };
 		99A0529A1F20A19B005600B3 /* YPAlbumVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A052991F20A19B005600B3 /* YPAlbumVC.swift */; };
 		99A0529D1F20B45D005600B3 /* YPAlbumView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A0529C1F20B45D005600B3 /* YPAlbumView.swift */; };
 		99A0529F1F20B480005600B3 /* YPAlbumCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A0529E1F20B480005600B3 /* YPAlbumCell.swift */; };
@@ -79,7 +83,11 @@
 		9911FA23203C3A31000E9B06 /* UIImage+ResetOrientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+ResetOrientation.swift"; sourceTree = "<group>"; };
 		991C0E5320567D3400764131 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		99472DEC2056E33700419F9E /* YPWordings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPWordings.swift; sourceTree = "<group>"; };
-		99472DEE2056E55B00419F9E /* YPPermissionDeniedPopup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPPermissionDeniedPopup.swift; sourceTree = "<group>"; };
+		99278DA720512BD90059532E /* PreiOS10PhotoCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreiOS10PhotoCapture.swift; sourceTree = "<group>"; };
+		99278DA920512BFB0059532E /* PostiOS10PhotoCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostiOS10PhotoCapture.swift; sourceTree = "<group>"; };
+		99278DAB20512C330059532E /* YPPhotoCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPPhotoCapture.swift; sourceTree = "<group>"; };
+		99278DAD205140F60059532E /* YPPermissionDeniedPopup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPPermissionDeniedPopup.swift; sourceTree = "<group>"; };
+		99278DAF2051816F0059532E /* YPPhotoCaptureDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPPhotoCaptureDefaults.swift; sourceTree = "<group>"; };
 		99A052991F20A19B005600B3 /* YPAlbumVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPAlbumVC.swift; sourceTree = "<group>"; };
 		99A0529C1F20B45D005600B3 /* YPAlbumView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPAlbumView.swift; sourceTree = "<group>"; };
 		99A0529E1F20B480005600B3 /* YPAlbumCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPAlbumCell.swift; sourceTree = "<group>"; };
@@ -182,6 +190,7 @@
 			isa = PBXGroup;
 			children = (
 				99C6D6B11F1FB5C100711DB2 /* YPHelpers.swift */,
+				99278DAD205140F60059532E /* YPPermissionDeniedPopup.swift */,
 				990FD294201B3E59002A39A1 /* YPDragDirection.swift */,
 				99C6D6B41F1FB5C100711DB2 /* YPPhotoSaver.swift */,
 				990FD28E201A49D3002A39A1 /* PermissionCheckable.swift */,
@@ -272,6 +281,10 @@
 			children = (
 				99C6D6A71F1FB5C100711DB2 /* YPCameraVC.swift */,
 				99C6D6A81F1FB5C100711DB2 /* YPCameraView.swift */,
+				99278DAB20512C330059532E /* YPPhotoCapture.swift */,
+				99278DA720512BD90059532E /* PreiOS10PhotoCapture.swift */,
+				99278DA920512BFB0059532E /* PostiOS10PhotoCapture.swift */,
+				99278DAF2051816F0059532E /* YPPhotoCaptureDefaults.swift */,
 			);
 			path = Camera;
 			sourceTree = "<group>";
@@ -382,7 +395,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		9945C1DD1E8141AB00AE1C57 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			files = (
 			);
 			inputPaths = (
@@ -390,7 +403,7 @@
 			name = SwiftLint;
 			outputPaths = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
@@ -404,12 +417,15 @@
 				99C6D6C81F1FB5C100711DB2 /* YPFiltersView.swift in Sources */,
 				990FD293201B3D69002A39A1 /* YPLibraryViewDelegate.swift in Sources */,
 				990FD28F201A49D3002A39A1 /* PermissionCheckable.swift in Sources */,
+				99278DA820512BD90059532E /* PreiOS10PhotoCapture.swift in Sources */,
 				99C6D6C71F1FB5C100711DB2 /* YPFiltersVC.swift in Sources */,
 				99D1DC2B1F9788930047F0E0 /* YPImagePickerConfiguration.swift in Sources */,
+				99278DAA20512BFB0059532E /* PostiOS10PhotoCapture.swift in Sources */,
 				990FD297201B4A5F002A39A1 /* PHCachingImageManager+Helpers.swift in Sources */,
 				99CF6D23201B71DC00487F77 /* YPLibrary+LibraryChange.swift in Sources */,
 				99C6D6C51F1FB5C100711DB2 /* YPFilterCollectionViewCell.swift in Sources */,
 				990FD295201B3E59002A39A1 /* YPDragDirection.swift in Sources */,
+				99278DAE205140F60059532E /* YPPermissionDeniedPopup.swift in Sources */,
 				99CF6D21201B70A000487F77 /* YPLibraryVC+CollectionView.swift in Sources */,
 				99CF6D1B201B6A5C00487F77 /* UICollectionView+IndexPath.swift in Sources */,
 				99C6D6C11F1FB5C100711DB2 /* YPImageCropViewContainer.swift in Sources */,
@@ -423,7 +439,9 @@
 				99472DEF2056E55B00419F9E /* YPPermissionDeniedPopup.swift in Sources */,
 				99CF6D1D201B6ABA00487F77 /* IndexSet+IndexPath.swift in Sources */,
 				9911FA24203C3A31000E9B06 /* UIImage+ResetOrientation.swift in Sources */,
+				99278DAC20512C330059532E /* YPPhotoCapture.swift in Sources */,
 				990FD291201B3CB4002A39A1 /* YPLibraryVC + UIHelpers.swift in Sources */,
+				99278DB02051816F0059532E /* YPPhotoCaptureDefaults.swift in Sources */,
 				99C6D6CE1F1FB5C100711DB2 /* YPPhotoSaver.swift in Sources */,
 				99C6D6C31F1FB5C100711DB2 /* YPCameraView.swift in Sources */,
 				99019E562018D008007325C2 /* YPMenuItem.swift in Sources */,
@@ -599,6 +617,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yummypets.YPImagePicker;
@@ -622,6 +641,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yummypets.YPImagePicker;


### PR DESCRIPTION
@NikKovIos here is the working progress, it works as expected, I just have a few
 things to clean & check for it to be mergeable

The approach taken here is to **abstract** the photo taking logic into a  `YPPhotoCapture` protocol.
Then we have two classes corresponding to the old and new apis that are used according to the current iOS version.

```swift
func newPhotoCapture() -> YPPhotoCapture {
    if #available(iOS 10.0, *) {
        return PostiOS10PhotoCapture()
    } else {
        return PreiOS10PhotoCapture()
    }
}
```
A benefit of this approach is that common code is shared to both classes is a YPPhotoCapture `extension`.
When the time comes we drop `iOS9` we'll just have to drop the `PreiOS10PhotoCapture` class.


Would love to know your thoughts,

Cheers,

Associated to : https://github.com/Yummypets/YPImagePicker/issues/43