### PR TITLE
Fix library quality

### DIFF
--- a/Source/Camera/PostiOS10PhotoCapture.swift
+++ b/Source/Camera/PostiOS10PhotoCapture.swift
@@ -104,9 +104,15 @@ class PostiOS10PhotoCapture: NSObject, YPPhotoCapture, AVCapturePhotoCaptureDele
         block?(data)
     }
     
-    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photoSampleBuffer: CMSampleBuffer?, previewPhoto previewPhotoSampleBuffer: CMSampleBuffer?, resolvedSettings: AVCaptureResolvedPhotoSettings, bracketSettings: AVCaptureBracketedStillImageSettings?, error: Error?) {
+    func photoOutput(_ output: AVCapturePhotoOutput,
+                     didFinishProcessingPhoto photoSampleBuffer: CMSampleBuffer?,
+                     previewPhoto previewPhotoSampleBuffer: CMSampleBuffer?,
+                     resolvedSettings: AVCaptureResolvedPhotoSettings,
+                     bracketSettings: AVCaptureBracketedStillImageSettings?,
+                     error: Error?) {
         guard let buffer = photoSampleBuffer else { return }
-        if let data = AVCapturePhotoOutput.jpegPhotoDataRepresentation(forJPEGSampleBuffer: buffer, previewPhotoSampleBuffer: previewPhotoSampleBuffer) {
+        if let data = AVCapturePhotoOutput.jpegPhotoDataRepresentation(forJPEGSampleBuffer: buffer,
+                                                                       previewPhotoSampleBuffer: previewPhotoSampleBuffer) {
             block?(data)
         }
     }


### PR DESCRIPTION
For some still obscure reasons using  `requestImage` was returning a lower quality image when zooming too much. All this even `options.deliveryMode` was set to `highQualityFormat`.


By using `requestImageData` instead, we get the raw full quality image data corresponding to the asset. Then we can crop it manually, which keeps the quality of the image intact :)