### PR TITLE
Removes Library loader glitch

### DIFF
--- a/Source/Library/YPImageCropViewContainer.swift
+++ b/Source/Library/YPImageCropViewContainer.swift
@@ -135,7 +135,7 @@ class YPImageCropViewContainer: UIView, YPImageCropViewDelegate, UIGestureRecogn
         curtain.fillContainer()
         
         spinner.startAnimating()
-        spinnerView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+        spinnerView.backgroundColor = UIColor.black.withAlphaComponent(0.3)
         playImageView.alpha = 0
         curtain.backgroundColor = UIColor.black.withAlphaComponent(0.5)
         curtain.alpha = 0

--- a/Source/Library/YPLibraryView.swift
+++ b/Source/Library/YPLibraryView.swift
@@ -92,14 +92,14 @@ extension YPLibraryView {
     
     // MARK: - Loader
     
-    func showLoader() {
-        imageCropViewContainer.spinnerView.alpha = 1
+    func fadeInLoader() {
+        UIView.animate(withDuration: 0.2) {
+            self.imageCropViewContainer.spinnerView.alpha = 1
+        }
     }
     
-    func fadeOutLoader() {
-        UIView.animate(withDuration: 0.2) {
-            self.imageCropViewContainer.spinnerView.alpha = 0
-        }
+    func hideLoader() {
+        imageCropViewContainer.spinnerView.alpha = 0
     }
     
     // MARK: - Crop Control

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -341,10 +341,12 @@ extension YPPickerVC: YPLibraryViewDelegate {
     }
     
     public func libraryViewFinishedLoadingImage() {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: configuration.wordings.next,
-                                                            style: .done,
-                                                            target: self,
-                                                            action: #selector(done))
+        DispatchQueue.main.async {
+            self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: self.configuration.wordings.next,
+                                                                style: .done,
+                                                                target: self,
+                                                                action: #selector(self.done))
+        }
     }
     
     public func libraryViewCameraRollUnauthorized() {


### PR DESCRIPTION
This removes the glitchy loader when Images are available fast enough.
However, the loader is kept when the high quality image takes more than 0.3 second to load.
Which 1 informs the user loading is taking time, 2 prevents the user form interacting with the media, such as panning/ zooming while it loads.
- Lighter loader (0.5 -> 0.3 black) similar to instagram