### PR TITLE
Allow to customize the list of filters using the configuration object

### DIFF
--- a/Source/Configuration/YPFilterDescriptor.swift
+++ b/Source/Configuration/YPFilterDescriptor.swift
@@ -1,0 +1,19 @@
+//
+//  YPFilterDescriptor.swift
+//  YPImagePicker
+//
+//  Created by Emil Atanasov on 14.04.18.
+//  Copyright © 2018 Yummypets. All rights reserved.
+//
+
+import Foundation
+
+public class YPFilterDescriptor {
+    let name:String
+    let filterName:String
+    
+    init(name: String, filterName: String ) {
+        self.name = name
+        self.filterName = filterName
+    }
+}

--- a/Source/Configuration/YPFilterDescriptor.swift
+++ b/Source/Configuration/YPFilterDescriptor.swift
@@ -12,7 +12,7 @@ public class YPFilterDescriptor {
     let name:String
     let filterName:String
     
-    init(name: String, filterName: String ) {
+    public init(name: String, filterName: String ) {
         self.name = name
         self.filterName = filterName
     }

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -78,4 +78,18 @@ public struct YPImagePickerConfiguration {
     
     /// Defines if the status bar should be hidden when showing the picker. Default is true
     public var hidesStatusBar = true
+    
+    /// List of default filters which will be added on the filter screen
+    public var filters:[YPFilterDescriptor] = [
+        YPFilterDescriptor(name: "Normal", filterName: ""),
+        YPFilterDescriptor(name: "Mono", filterName: "CIPhotoEffectMono"),
+        YPFilterDescriptor(name: "Tonal", filterName: "CIPhotoEffectTonal"),
+        YPFilterDescriptor(name: "Noir", filterName: "CIPhotoEffectNoir"),
+        YPFilterDescriptor(name: "Fade", filterName: "CIPhotoEffectFade"),
+        YPFilterDescriptor(name: "Chrome", filterName: "CIPhotoEffectChrome"),
+        YPFilterDescriptor(name: "Process", filterName: "CIPhotoEffectProcess"),
+        YPFilterDescriptor(name: "Transfer", filterName: "CIPhotoEffectTransfer"),
+        YPFilterDescriptor(name: "Instant", filterName: "CIPhotoEffectInstant"),
+        YPFilterDescriptor(name: "Sepia", filterName: "CISepiaTone")
+    ]
 }

--- a/Source/Filters/YPFiltersVC.swift
+++ b/Source/Filters/YPFiltersVC.swift
@@ -29,34 +29,12 @@ class YPFiltersVC: UIViewController {
         title = configuration.wordings.filter
         self.originalImage = image
         
-        filterPreviews = [
-            YPFilterPreview("Normal"),
-            YPFilterPreview("Mono"),
-            YPFilterPreview("Tonal"),
-            YPFilterPreview("Noir"),
-            YPFilterPreview("Fade"),
-            YPFilterPreview("Chrome"),
-            YPFilterPreview("Process"),
-            YPFilterPreview("Transfer"),
-            YPFilterPreview("Instant"),
-            YPFilterPreview("Sepia")
-        ]
+        filterPreviews = []
         
-        let filterNames = [
-            "",
-            "CIPhotoEffectMono",
-            "CIPhotoEffectTonal",
-            "CIPhotoEffectNoir",
-            "CIPhotoEffectFade",
-            "CIPhotoEffectChrome",
-            "CIPhotoEffectProcess",
-            "CIPhotoEffectTransfer",
-            "CIPhotoEffectInstant",
-            "CISepiaTone"
-        ]
-        
-        for fn in filterNames {
-            filters.append(YPFilter(fn))
+        //use the configuration to create all filters
+        for filterDescriptor in configuration.filters {
+            filterPreviews.append(YPFilterPreview(filterDescriptor.name))
+            filters.append(YPFilter(filterDescriptor.filterName))
         }
     }
     

--- a/YPImagePicker.xcodeproj/project.pbxproj
+++ b/YPImagePicker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		20B6BB042081E065009064E9 /* YPFilterDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B6BB032081E065009064E9 /* YPFilterDescriptor.swift */; };
 		99019E4C2018CCD6007325C2 /* YPBottomPagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99019E4B2018CCD6007325C2 /* YPBottomPagerView.swift */; };
 		99019E4E2018CD31007325C2 /* YPPagerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99019E4D2018CD31007325C2 /* YPPagerMenu.swift */; };
 		99019E512018CDED007325C2 /* YPLibraryImageSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99019E502018CDED007325C2 /* YPLibraryImageSize.swift */; };
@@ -68,6 +69,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		20B6BB032081E065009064E9 /* YPFilterDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPFilterDescriptor.swift; sourceTree = "<group>"; };
 		3B0E1B962070669B0048E95B /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		52412A931CA6114A0073C4BE /* YPImagePicker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YPImagePicker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7157B4CA206FD7270004EF6C /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -182,6 +184,7 @@
 			isa = PBXGroup;
 			children = (
 				99D1DC2A1F9788930047F0E0 /* YPImagePickerConfiguration.swift */,
+				20B6BB032081E065009064E9 /* YPFilterDescriptor.swift */,
 				99472DEC2056E33700419F9E /* YPWordings.swift */,
 				99019E502018CDED007325C2 /* YPLibraryImageSize.swift */,
 				99019E522018CE19007325C2 /* YPPickerScreen.swift */,
@@ -462,6 +465,7 @@
 				99A3C91220319231008D7E23 /* YPCropVC.swift in Sources */,
 				99019E512018CDED007325C2 /* YPLibraryImageSize.swift in Sources */,
 				99CF6D25201B727900487F77 /* YPLibraryVC+PanGesture.swift in Sources */,
+				20B6BB042081E065009064E9 /* YPFilterDescriptor.swift in Sources */,
 				99CF6D27201B739600487F77 /* YPAlerts.swift in Sources */,
 				99C6D6CF1F1FB5C100711DB2 /* YPPickerVC.swift in Sources */,
 				99CF6D29201B900400487F77 /* LibraryMediaManager.swift in Sources */,

--- a/YPImagePickerExample/YPImagePickerExample/ViewController.swift
+++ b/YPImagePickerExample/YPImagePickerExample/ViewController.swift
@@ -57,7 +57,14 @@ class ViewController: UIViewController {
 //        config.usesFrontCamera = true
 //
 //        /// Adds a Filter step in the photo taking process.  Defaults to true
-        config.showsFilters = false
+        config.showsFilters = !false
+        
+        config.filters.remove(at: 1)
+        config.filters.remove(at: 1)
+        config.filters.remove(at: 1)
+        config.filters.insert(YPFilterDescriptor(name: "Blur" , filterName: "CIBoxBlur"), at: 1)
+        
+        
 //
 //        /// Enables you to opt out from saving new (or old but filtered) images to the
 //        /// user's photo library. Defaults to true.


### PR DESCRIPTION
Expose a new class YPFilterDescriptor which can be used to add new filters to the collection of predefined ones. The demo project is updated as well. In future, the descriptor class may be extended to allow fine tuning of each filter.