### PR TITLE
Configuration option to disable photos within the library 

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -33,6 +33,9 @@ public struct YPImagePickerConfiguration {
     /// Enables videos within the library and video taking. Defaults to false
     @available(*, unavailable, renamed:"showsVideoInLibrary")
     public var showsVideo = false
+
+    /// Disables photos within the library. Defaults to true
+    public var showsPhotosInLibrary = false
     
     /// Enables videos within the library. Defaults to false
     public var showsVideoInLibrary = false

--- a/Source/Library/YPLibraryVC.swift
+++ b/Source/Library/YPLibraryVC.swift
@@ -144,21 +144,8 @@ public class YPLibraryVC: UIViewController, PermissionCheckable {
     }
     
     func refreshMediaRequest() {
-        
-        // Sorting condition
-        let options = PHFetchOptions()
-        options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
 
-        switch (configuration.showsPhotosInLibrary, configuration.showsVideoInLibrary) {
-        case (true, true):
-            options.predicate = NSPredicate(format: "mediaType = %d || mediaType = %d",
-                                            PHAssetMediaType.image.rawValue, PHAssetMediaType.video.rawValue)
-        case (true, false):
-            options.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.image.rawValue)
-        case (false, true):
-            options.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.video.rawValue)
-        case (false, false): break // Show everything 🤔 perhaps an assertionFailure?
-        }
+        let options = buildPHFetchOptions()
 
         if let collection = mediaManager.collection {
             mediaManager.fetchResult = PHAsset.fetchAssets(in: collection, options: options)
@@ -174,6 +161,26 @@ public class YPLibraryVC: UIViewController, PermissionCheckable {
                                              scrollPosition: UICollectionViewScrollPosition())
         }
         scrollToTop()
+    }
+
+    func buildPHFetchOptions() -> PHFetchOptions {
+        // Sorting condition
+        let options = PHFetchOptions()
+        options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+
+        // Create predicate based on configuration showPhotosInLibrary and showsVideoInLibrary
+        switch (configuration.showsPhotosInLibrary, configuration.showsVideoInLibrary) {
+        case (true, true):
+            options.predicate = NSPredicate(format: "mediaType = %d || mediaType = %d",
+                                            PHAssetMediaType.image.rawValue, PHAssetMediaType.video.rawValue)
+        case (true, false):
+            options.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.image.rawValue)
+        case (false, true):
+            options.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.video.rawValue)
+        case (false, false): break // Show everything 🤔 perhaps an assertionFailure?
+        }
+
+        return options
     }
     
     func scrollToTop() {

--- a/Source/Library/YPLibraryVC.swift
+++ b/Source/Library/YPLibraryVC.swift
@@ -148,16 +148,22 @@ public class YPLibraryVC: UIViewController, PermissionCheckable {
         // Sorting condition
         let options = PHFetchOptions()
         options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-        
-        if let collection = self.mediaManager.collection {
-            if !configuration.showsVideoInLibrary {
-                options.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.image.rawValue)
-            }
+
+        switch (configuration.showsPhotosInLibrary, configuration.showsVideoInLibrary) {
+        case (true, true):
+            options.predicate = NSPredicate(format: "mediaType = %d || mediaType = %d",
+                                            PHAssetMediaType.image.rawValue, PHAssetMediaType.video.rawValue)
+        case (true, false):
+            options.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.image.rawValue)
+        case (false, true):
+            options.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.video.rawValue)
+        case (false, false): break // Show everything 🤔 perhaps an assertionFailure?
+        }
+
+        if let collection = mediaManager.collection {
             mediaManager.fetchResult = PHAsset.fetchAssets(in: collection, options: options)
         } else {
-            mediaManager.fetchResult = configuration.showsVideoInLibrary
-                ? PHAsset.fetchAssets(with: options)
-                : PHAsset.fetchAssets(with: PHAssetMediaType.image, options: options)
+            mediaManager.fetchResult = PHAsset.fetchAssets(with: options)
         }
         
         if mediaManager.fetchResult.count > 0 {


### PR DESCRIPTION
Hello 👋 

First of all, nice lib, one of the best pickers i have tried and the one i choose for my current project.

So i have a requirement in my project, which is only support videos in the library viewer and so i decided to do the changes and submit a pull request 😅 (and 🙏)

So what did i change: 👇 

👉  Added new parameter in the configuration to support disable photos in
library
👉  Updated refreshMediaRequest to apply new filter

And it's basically that.

I left a comment and i would like to hear your thoughts around that, when the user doesn't selects photos neither videos, what should the library show.

Thanks 🍻 🙏 