### PR TITLE
Fix: Filters don't stack anymore + preview + defer save at the end

### DIFF
--- a/Source/Models/YPMediaItem.swift
+++ b/Source/Models/YPMediaItem.swift
@@ -10,12 +10,15 @@ import UIKit
 import Foundation
 import AVFoundation
 
-public struct YPPhoto {
-    public let image: UIImage
+public class YPPhoto {
+    public var image: UIImage { return modifiedImage ?? originalImage }
+    public let originalImage: UIImage
+    public var modifiedImage: UIImage?
     public let fromCamera: Bool
     
     init(image: UIImage, fromCamera: Bool = false) {
-        self.image = image
+        self.originalImage = image
+        self.modifiedImage = nil
         self.fromCamera = fromCamera
     }
 }

--- a/Source/SelectionsGallery/YPSelectionsGalleryVC.swift
+++ b/Source/SelectionsGallery/YPSelectionsGalleryVC.swift
@@ -42,7 +42,16 @@ public class YPSelectionsGalleryVC: UIViewController {
         YPHelper.changeBackButtonTitle(self)
     }
 
-    @objc private func done() {
+    @objc
+    private func done() {
+        // Save new images to the photo album.
+        if YPConfig.shouldSaveNewPicturesToAlbum {
+            for m in items {
+                if case let .photo(p) = m, let modifiedImage = p.modifiedImage {
+                    YPPhotoSaver.trySaveImage(modifiedImage, inAlbumNamed: YPConfig.albumName)
+                }
+            }
+        }
         YPConfig.delegate?.imagePicker(imagePicker, didSelect: items)
     }
 }
@@ -55,7 +64,6 @@ extension YPSelectionsGalleryVC: UICollectionViewDataSource {
     
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "item", for: indexPath) as! YPSelectionsGalleryCVCell
-        
         let item = items[indexPath.row]
         switch item {
         case .photo(let photo):
@@ -63,7 +71,6 @@ extension YPSelectionsGalleryVC: UICollectionViewDataSource {
         case .video(let video):
             cell.imageV.image = video.thumbnail
         }
-        
         return cell
     }
 }

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -63,21 +63,26 @@ public class YPImagePicker: UINavigationController {
             
             switch item {
             case .photo(let photo):
-                // TODO: Save new photo ?
-                let completion = { (image: UIImage) in
-                    let mediaItem = YPMediaItem.photo(p: YPPhoto(image: image))
+                
+                let completion = { (photo: YPPhoto) in
+                    let mediaItem = YPMediaItem.photo(p: photo)
+                    // Save new image to the photo album.
+                    if YPConfig.shouldSaveNewPicturesToAlbum, let modifiedImage = photo.modifiedImage {
+                        YPPhotoSaver.trySaveImage(modifiedImage, inAlbumNamed: YPConfig.albumName)
+                    }
                     YPConfig.delegate?.imagePicker(self, didSelect: [mediaItem])
                 }
                 
-                func showCropVC(photo: YPPhoto, completion: @escaping (_ image: UIImage) -> Void) {
+                func showCropVC(photo: YPPhoto, completion: @escaping (_ aphoto: YPPhoto) -> Void) {
                     if case let YPCropType.rectangle(ratio) = YPConfig.showsCrop {
                         let cropVC = YPCropVC(image: photo.image, ratio: ratio)
                         cropVC.didFinishCropping = { croppedImage in
-                            completion(croppedImage)
+                            photo.modifiedImage = croppedImage
+                            completion(photo)
                         }
                         self.pushViewController(cropVC, animated: true)
                     } else {
-                        completion(photo.image)
+                        completion(photo)
                     }
                 }
                 


### PR DESCRIPTION
- Filters don't stack anymore, the original image is always kept in memory
- A nice preview is added so that users can see the original image when touching the preview
- Saving the modified images has been deferred to the end of the flow to prevent wrong saves when editing filters in multiple selection mode