### PR TITLE
Test didfinishPicking

### DIFF
--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -11,10 +11,20 @@ import AVFoundation
 
 public class YPImagePicker: UINavigationController {
     
+    @available(*, deprecated, message: "Use didFinishPicking callback instead")
     public var didSelectImage: ((UIImage) -> Void)?
+    @available(*, deprecated, message: "Use didFinishPicking callback instead")
     public var didSelectVideo: ((Data, UIImage, URL) -> Void)?
-    public var didSelectItems: (([YPMediaItem]) -> Void)?
+    
+    @available(*, deprecated, message: "Use didFinishPicking callback instead")
     public var didCancel: (() -> Void)?
+    
+    
+    private var _didFinishPicking: (([YPMediaItem], Bool) -> Void)?
+    public func didFinishPicking(completion: @escaping (_ items: [YPMediaItem], _ cancelled: Bool) -> Void) {
+        _didFinishPicking = completion
+    }
+    
     
     // This nifty little trick enables us to call the single version of the callbacks.
     // This keeps the backwards compatibility keeps the api as simple as possible.
@@ -27,9 +37,11 @@ public class YPImagePicker: UINavigationController {
                 pickedVideo.fetchData { videoData in
                     didSelectVideo(videoData, pickedVideo.thumbnail, pickedVideo.url)
                 }
+            } else {
+                _didFinishPicking?(items, false)
             }
         } else {
-            didSelectItems?(items)
+            _didFinishPicking?(items, false)
         }
     }
     
@@ -54,7 +66,10 @@ public class YPImagePicker: UINavigationController {
     
     override public func viewDidLoad() {
         super.viewDidLoad()
-        picker.didClose = didCancel
+        picker.didClose = { [weak self] in
+            self?.didCancel?()
+            self?._didFinishPicking?([], true)
+        }
         viewControllers = [picker]
         setupLoadingView()
         navigationBar.isTranslucent = false
@@ -141,5 +156,22 @@ public class YPImagePicker: UINavigationController {
         )
         loadingView.fillContainer()
         loadingView.alpha = 0
+    }
+}
+
+public extension Array where Element == YPMediaItem {
+    
+    public var singlePhoto: YPMediaPhoto? {
+        if let f = first, case let .photo(p) = f {
+            return p
+        }
+        return nil
+    }
+    
+    public var singleVideo: YPMediaVideo? {
+        if let f = first, case let .video(v) = f {
+            return v
+        }
+        return nil
     }
 }

--- a/YPImagePickerExample/YPImagePickerExample/ViewController.swift
+++ b/YPImagePickerExample/YPImagePickerExample/ViewController.swift
@@ -119,26 +119,40 @@ class ViewController: UIViewController {
         /// Change configuration directly
 //        YPImagePickerConfiguration.shared.wordings.libraryTitle = "Gallery2"
 
+    
+//        picker.didSelectImage = { [unowned picker] img in
+//            // image picked
+//            print(img.size)
+//            self.imageView.image = img
+//            picker.dismiss(animated: true, completion: nil)
+//        }
+//        picker.didSelectVideo = { videoData, videoThumbnailImage, videoURL in
+//            // video picked
+//            print(videoData)
+//            print(videoURL)
+//            self.imageView.image = videoThumbnailImage
+//            picker.dismiss(animated: true, completion: nil)
+//        }
+//        picker.didCancel = {
+//            print("Did Cancel")
+//        }
         
-        picker.didSelectImage = { [unowned picker] img in
-            // image picked
-            print(img.size)
-            self.imageView.image = img
+
+        
+        // Single Photo implementation.
+        picker.didFinishPicking { items, cancelled in
+            self.imageView.image = items.singlePhoto?.image
             picker.dismiss(animated: true, completion: nil)
-        }
-        picker.didSelectVideo = { videoData, videoThumbnailImage, videoURL in
-            // video picked
-            print(videoData)
-            print(videoURL)
-            self.imageView.image = videoThumbnailImage
-            picker.dismiss(animated: true, completion: nil)
-        }
-        picker.didCancel = {
-            print("Did Cancel")
         }
         
-        picker.didSelectItems = { [unowned picker] items in
+        // Single Video implementation.
+        picker.didFinishPicking { items, cancelled in
+            self.imageView.image = items.singleVideo?.thumbnail
             picker.dismiss(animated: true, completion: nil)
+        }
+        
+        // Multiple implementation
+        picker.didFinishPicking { items, cancelled in
             _ = items.map { print("🧀 \($0)") }
             if let firstItem = items.first {
                 switch firstItem {
@@ -148,6 +162,7 @@ class ViewController: UIViewController {
                     self.imageView.image = video.thumbnail
                 }
             }
+            picker.dismiss(animated: true, completion: nil)
         }
         
         present(picker, animated: true, completion: nil)


### PR DESCRIPTION
## Make the api as simple as possible
Use a single callback in the future: `didFinishPicking`

 ## Minimize code changes on the user's side
Keep backwards compatibility with `didSelectImage`, `didSelectVideo` `didCancel` but deprecate them in favor of `didFinishPicking`. This way the transition is smoother for the users.

 ## Keep the "single" asset use case straightforward
By having a nice `singlePhoto: YPMediaPhoto?` shortcut on the `[YPMediaItem]` array, we simplify the single asset use case.

 ## Examples

### Single photo use case (very common)
```swift
picker.didFinishPicking { items, cancelled in
    self.imageView.image = items.singlePhoto?.image
    picker.dismiss(animated: true, completion: nil)
}
```

### Single video
```swift
picker.didFinishPicking { items, cancelled in
    self.imageView.image = items.singleVideo?.thumbnail
    picker.dismiss(animated: true, completion: nil)
}
```

### Multiple selection
```swift
picker.didFinishPicking { items, cancelled in
    _ = items.map { print("🧀 \($0)") }
    if let firstItem = items.first {
        switch firstItem {
        case .photo(let photo):
            self.imageView.image = photo.image
        case .video(let video):
            self.imageView.image = video.thumbnail
        }
    }
    picker.dismiss(animated: true, completion: nil)
}
```

### Cancelation
```swift
picker.didFinishPicking { items, cancelled in
  if cancelled {
    print("user cancelled")
  } else {
    print("user chose a pic") 
  }
  picker.dismiss(animated: true, completion: nil)
}
```

This is **fully backwards compatible** with the previous api, yet pushing the users the make the switch to the newest one. By using the new one, they get the multiple selection feature!