### PR TITLE
Tint color

### DIFF
--- a/Source/Configuration/YPColors.swift
+++ b/Source/Configuration/YPColors.swift
@@ -11,10 +11,7 @@ import UIKit
 public struct YPColors {
     
     public var tintColor = UIColor.red
-    
-    /// A color for navigation bar text
-    public var navigationBarTextColor = UIColor.black
-    
+        
     /// A color for navigation bar spinner
     /// Default is nil, which is default iOS gray UIActivityIndicator
     public var navigationBarActivityIndicatorColor: UIColor?

--- a/Source/Configuration/YPColors.swift
+++ b/Source/Configuration/YPColors.swift
@@ -9,14 +9,19 @@
 import UIKit
 
 public struct YPColors {
+    
+    public var tintColor = UIColor.red
+    
     /// A color for navigation bar text
     public var navigationBarTextColor = UIColor.black
     
     /// A color for navigation bar spinner
-    public var navigationBarActivityIndicatorColor = UIColor.black
+    /// Default is nil, which is default iOS gray UIActivityIndicator
+    public var navigationBarActivityIndicatorColor: UIColor?
     
     /// A color for circle for selected items in multiple selection
-    public var multipleItemsSelectedCircleColor: UIColor = UIColor.blue
+    /// Default is nil, which takes tintColor.
+    public var multipleItemsSelectedCircleColor: UIColor?
     
     // Trimmer
     /// The color of the main border of the view

--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -82,9 +82,11 @@ public class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
         }
         let rightBarButtonTitle = isFromSelectionVC ? YPConfig.wordings.done : YPConfig.wordings.next
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: rightBarButtonTitle,
-                                                            style: .plain,
+                                                            style: .done,
                                                             target: self,
                                                             action: #selector(save))
+        navigationItem.rightBarButtonItem?.tintColor = YPConfig.colors.tintColor
+        
         YPHelper.changeBackButtonTitle(self)
     }
     
@@ -109,7 +111,7 @@ public class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
     
     @objc public func save() {
         guard let didSave = didSave else { return print("Don't have saveCallback") }
-        YPLoaders.enableActivityIndicator(barButtonItem: &self.navigationItem.rightBarButtonItem)
+        navigationItem.rightBarButtonItem = YPLoaders.defaultLoader
 
         do {
             let asset = AVURLAsset(url: inputVideo.url)

--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -73,7 +73,6 @@ public class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
         
         // Navigation bar setup
         title = YPConfig.wordings.trim
-        navigationController?.navigationBar.tintColor = YPConfig.colors.navigationBarTextColor
         if isFromSelectionVC {
             navigationItem.leftBarButtonItem = UIBarButtonItem(title: YPConfig.wordings.cancel,
                                                                style: .plain,

--- a/Source/Filters/YPPhotoFiltersVC.swift
+++ b/Source/Filters/YPPhotoFiltersVC.swift
@@ -83,9 +83,11 @@ open class YPPhotoFiltersVC: UIViewController, IsMediaFilterVC, UIGestureRecogni
         }
         let rightBarButtonTitle = isFromSelectionVC ? YPConfig.wordings.done : YPConfig.wordings.next
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: rightBarButtonTitle,
-                                                            style: .plain,
+                                                            style: .done,
                                                             target: self,
                                                             action: #selector(save))
+        navigationItem.rightBarButtonItem?.tintColor = YPConfig.colors.tintColor
+        
         YPHelper.changeBackButtonIcon(self)
         YPHelper.changeBackButtonTitle(self)
         

--- a/Source/Filters/YPPhotoFiltersVC.swift
+++ b/Source/Filters/YPPhotoFiltersVC.swift
@@ -74,7 +74,6 @@ open class YPPhotoFiltersVC: UIViewController, IsMediaFilterVC, UIGestureRecogni
         
         // Navigation bar setup
         title = YPConfig.wordings.filter
-        navigationController?.navigationBar.tintColor = YPConfig.colors.navigationBarTextColor
         if isFromSelectionVC {
             navigationItem.leftBarButtonItem = UIBarButtonItem(title: YPConfig.wordings.cancel,
                                                                 style: .plain,

--- a/Source/Helpers/YPLoaders.swift
+++ b/Source/Helpers/YPLoaders.swift
@@ -9,21 +9,11 @@
 import UIKit
 
 struct YPLoaders {
-    public static func enableActivityIndicator(barButtonItem: inout UIBarButtonItem?) {
-        let spinner = UIActivityIndicatorView(activityIndicatorStyle: UIActivityIndicatorViewStyle.gray)
+
+    static var defaultLoader: UIBarButtonItem {
+        let spinner = UIActivityIndicatorView(activityIndicatorStyle: .gray)
         spinner.color = YPConfig.colors.navigationBarActivityIndicatorColor
-        barButtonItem = UIBarButtonItem(customView: spinner)
         spinner.startAnimating()
-    }
-    
-    public static func disableActivityIndicator(barButtonItem: inout UIBarButtonItem?,
-                                                title: String,
-                                                target: Any,
-                                                action: Selector) {
-        barButtonItem = UIBarButtonItem(title: title,
-                                        style: .plain,
-                                        target: target,
-                                        action: action)
-        barButtonItem?.tintColor = YPConfig.colors.navigationBarTextColor
+        return UIBarButtonItem(customView: spinner)
     }
 }

--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -99,7 +99,7 @@ extension YPLibraryVC: UICollectionViewDelegate {
                                                                 fatalError("unexpected cell in collection view")
         }
         cell.representedAssetIdentifier = asset.localIdentifier
-        cell.multipleSelectionIndicator.selectionColor = YPConfig.colors.multipleItemsSelectedCircleColor
+        cell.multipleSelectionIndicator.selectionColor = YPConfig.colors.multipleItemsSelectedCircleColor ?? YPConfig.colors.tintColor
         mediaManager.imageManager?.requestImage(for: asset,
                                    targetSize: v.cellSize(),
                                    contentMode: .aspectFill,

--- a/Source/SelectionsGallery/YPSelectionsGalleryVC.swift
+++ b/Source/SelectionsGallery/YPSelectionsGalleryVC.swift
@@ -36,9 +36,11 @@ public class YPSelectionsGalleryVC: UIViewController {
         
         // Setup navigation bar
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: YPConfig.wordings.next,
-                                                            style: .plain,
+                                                            style: .done,
                                                             target: self,
                                                             action: #selector(done))
+        navigationItem.rightBarButtonItem?.tintColor = YPConfig.colors.tintColor
+        
         YPHelper.changeBackButtonIcon(self)
         YPHelper.changeBackButtonTitle(self)
     }

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -256,11 +256,10 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         case .library:
             setTitleViewWithTitle(aTitle: libraryVC?.title ?? "")
             navigationItem.rightBarButtonItem = UIBarButtonItem(title: YPConfig.wordings.next,
-                                                                style: .plain,
+                                                                style: .done,
                                                                 target: self,
                                                                 action: #selector(done))
-            navigationItem.rightBarButtonItem?.tintColor = YPConfig.colors.navigationBarTextColor
-            navigationItem.rightBarButtonItem?.isEnabled = true
+            navigationItem.rightBarButtonItem?.tintColor = YPConfig.colors.tintColor
         case .camera:
             navigationItem.titleView = nil
             title = cameraVC?.title
@@ -308,20 +307,18 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
 }
 
 extension YPPickerVC: YPLibraryViewDelegate {
+    
     public func libraryViewStartedLoading() {
         DispatchQueue.main.async {
             self.libraryVC?.v.fadeInLoader()
-            YPLoaders.enableActivityIndicator(barButtonItem: &self.navigationItem.rightBarButtonItem)
+            self.navigationItem.rightBarButtonItem = YPLoaders.defaultLoader
         }
     }
     
     public func libraryViewFinishedLoading() {
         DispatchQueue.main.async {
             self.libraryVC?.v.hideLoader()
-            YPLoaders.disableActivityIndicator(barButtonItem: &self.navigationItem.rightBarButtonItem,
-                                               title: YPConfig.wordings.next,
-                                               target: self,
-                                               action: #selector(self.done))
+            self.updateUI()
         }
     }
     

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -210,14 +210,17 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         
         let label = UILabel()
         label.text = aTitle
-        label.textColor = YPConfig.colors.navigationBarTextColor
-        
+        // Use standard font by default.
+        label.font = UIFont.boldSystemFont(ofSize: 17)
+
+        // Use custom font if set by user.
         if let navBarTitleFont = UINavigationBar.appearance().titleTextAttributes?[.font] as? UIFont {
             // Use custom font if set by user.
             label.font = navBarTitleFont
-        } else {
-            // Use standard font by default.
-            label.font = UIFont.boldSystemFont(ofSize: 17)
+        }
+        // Use custom textColor if set by user.
+        if let navBarTitleColor = UINavigationBar.appearance().titleTextAttributes?[.foregroundColor] as? UIColor {
+            label.textColor = navBarTitleColor
         }
         
         let arrow = UIImageView()
@@ -250,7 +253,6 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
                                                            style: .plain,
                                                            target: self,
                                                            action: #selector(close))
-        navigationItem.leftBarButtonItem?.tintColor = YPConfig.colors.navigationBarTextColor
         
         switch mode {
         case .library:


### PR DESCRIPTION
### Bugfix
- Fixes Actions buttons not being bold by setting them with the `done` style


### Setting "Main" color
```swift
config.colors.tintColor = .red
```
This will set all the "action" buttons to `red`, and also the multiple selection indicator.

In the case where users want a different color for the multiple selection, users can set : 
```swift
config.colors.multipleItemsSelectedCircleColor = .blue
```
explicitely.

### Setting Navigation Bar classic buttons color

```swift
UINavigationBar.appearance().tintColor = .black
```

### Setting Navigation Bar title color
Removing `navigationBarTextColor`. 
The users can change it through the native appearance proxy api.

```swift
UINavigationBar.appearance().titleTextAttributes = [NSAttributedStringKey.foregroundColor : UIColor.red]
```
This is more consistent since changing the font was already supported that way.
