### PR TITLE
Image with EXIF meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .DS_Store
 
 # Xcode
-# build/
+build/
 *.pbxuser
 !default.pbxuser
 *.mode1v3

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ picker.didFinishPicking { items, _ in
         print(photo.image) // Final image selected by the user
         print(photo.originalImage) // original image selected by the user, unfiltered
         print(photo.modifiedImage) // Transformed image, can be nil
+        print(photo.exifMeta) // Print exif meta data of original image.
     }
     picker.dismiss(animated: true, completion: nil)
 }

--- a/Source/Helpers/YPHelper.swift
+++ b/Source/Helpers/YPHelper.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import UIKit
+import Photos
 
 internal func ypLocalized(_ str: String) -> String {
     return NSLocalizedString(str,
@@ -64,5 +65,28 @@ struct YPHelper {
         let seconds = interval % 60
         let minutes = (interval / 60) % 60
         return String(format: "%02d:%02d", minutes, seconds)
+    }
+    
+    public static func unwrapImageMetaAssets(asset : PHAsset) -> [String : Any]?{
+        let imageRequestOptions = PHImageRequestOptions()
+        imageRequestOptions.isSynchronous = true
+        
+        var returnValue = [String : Any]()
+        
+        PHImageManager.default().requestImageData(for: asset, options: imageRequestOptions) { (data, dataUTI, orientation, info) in
+            
+            returnValue = self.metadataForImageData(data: data!)
+        }
+        
+        return returnValue
+    }
+    
+    private static func metadataForImageData(data : Data) -> [String : Any]{
+        let imageSource = CGImageSourceCreateWithData(data as CFData, nil)
+        
+        let imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource!, 0, nil)
+        
+        return imageProperties! as! [String : Any]
+        
     }
 }

--- a/Source/Models/YPMediaItem.swift
+++ b/Source/Models/YPMediaItem.swift
@@ -15,11 +15,13 @@ public class YPMediaPhoto {
     public let originalImage: UIImage
     public var modifiedImage: UIImage?
     public let fromCamera: Bool
+    public let exifMeta : [String : Any]?
     
-    init(image: UIImage, fromCamera: Bool = false) {
+    init(image: UIImage, exifMeta : [String : Any]? = nil, fromCamera: Bool = false) {
         self.originalImage = image
         self.modifiedImage = nil
         self.fromCamera = fromCamera
+        self.exifMeta = exifMeta
     }
 }
 

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -365,7 +365,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         }
     }
     
-    public func selectedMedia(photoCallback: @escaping (_ photo: UIImage) -> Void,
+    public func selectedMedia(photoCallback: @escaping (_ photo: UIImage, _ exifMeta : [String : Any]?) -> Void,
                               videoCallback: @escaping (_ videoURL: URL) -> Void,
                               multipleItemsCallback: @escaping (_ items: [YPMediaItem]) -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
@@ -394,7 +394,9 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                     case .image:
                         self.fetchImageAndCrop(for: asset.asset, withCropRect: asset.cropRect) { image in
                             let resizedImage = self.resizedImageIfNeeded(image: image)
-                            let photo = YPMediaPhoto(image: resizedImage)
+                            let exifMeta = YPHelper.unwrapImageMetaAssets(asset: asset.asset)
+                            let photo = YPMediaPhoto(image: resizedImage, exifMeta: exifMeta)
+                            
                             resultMediaItems.append(YPMediaItem.photo(p: photo))
                             asyncGroup.leave()
                         }
@@ -430,7 +432,9 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                         DispatchQueue.main.async {
                             self.delegate?.libraryViewFinishedLoading()
                             let resizedImage = self.resizedImageIfNeeded(image: image)
-                            photoCallback(resizedImage)
+                            let exifMeta = YPHelper.unwrapImageMetaAssets(asset: asset)
+                            
+                            photoCallback(resizedImage, exifMeta)
                         }
                     }
                 case .audio, .unknown:

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -21,13 +21,13 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     /// Private callbacks to YPImagePicker
     public var didClose:(() -> Void)?
     public var didSelectItems: (([YPMediaItem]) -> Void)?
-
+    
     enum Mode {
         case library
         case camera
         case video
     }
-
+    
     private var libraryVC: YPLibraryVC?
     private var cameraVC: YPCameraVC?
     private var videoVC: YPVideoVC?
@@ -38,9 +38,9 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         view.backgroundColor = UIColor(r: 247, g: 247, b: 247)
-
+        
         delegate = self
         
         // Library
@@ -54,7 +54,7 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
             cameraVC = YPCameraVC()
             cameraVC?.didCapturePhoto = { [unowned self] img in
                 self.didSelectItems?([YPMediaItem.photo(p: YPMediaPhoto(image: img,
-                                                                   fromCamera: true))])
+                                                                        fromCamera: true))])
             }
         }
         
@@ -64,11 +64,11 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
             videoVC?.didCaptureVideo = { [unowned self] videoURL in
                 self.didSelectItems?([YPMediaItem
                     .video(v: YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
-                                      videoURL: videoURL,
-                                      fromCamera: true))])
+                                           videoURL: videoURL,
+                                           fromCamera: true))])
             }
         }
-    
+        
         // Show screens
         var vcs = [UIViewController]()
         for screen in YPConfig.screens {
@@ -88,7 +88,7 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
             }
         }
         controllers = vcs
-      
+        
         // Select good mode
         if YPConfig.screens.contains(YPConfig.startOnScreen) {
             switch YPConfig.startOnScreen {
@@ -192,7 +192,7 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     func navBarTapped() {
         let vc = YPAlbumVC()
         let navVC = UINavigationController(rootViewController: vc)
-
+        
         vc.didSelectAlbum = { [weak self] album in
             self?.libraryVC?.setAlbum(album)
             self?.libraryVC?.title = album.title
@@ -211,7 +211,7 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         label.text = aTitle
         // Use standard font by default.
         label.font = UIFont.boldSystemFont(ofSize: 17)
-
+        
         // Use custom font if set by user.
         if let navBarTitleFont = UINavigationBar.appearance().titleTextAttributes?[.font] as? UIFont {
             // Use custom font if set by user.
@@ -286,13 +286,13 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         
         if mode == .library {
             libraryVC.doAfterPermissionCheck { [weak self] in
-                libraryVC.selectedMedia(photoCallback: { img in
+                libraryVC.selectedMedia(photoCallback: { img, exifMeta in
                     self?.didSelectItems?([YPMediaItem
-                        .photo(p: YPMediaPhoto(image: img))])
+                        .photo(p: YPMediaPhoto(image: img, exifMeta: exifMeta))])
                 }, videoCallback: { videoURL in
                     self?.didSelectItems?([YPMediaItem
                         .video(v: YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
-                                          videoURL: videoURL))])
+                                               videoURL: videoURL))])
                 }, multipleItemsCallback: { items in
                     self?.didSelectItems?(items)
                 })


### PR DESCRIPTION
In `didFinishPicking` function, we lose access of assets meta data(EXIF). Information like GPS, and capture device can not access from this point.
I wrote small patch that add `exifMeta` property to `YPMediaPhoto` class.  