### PR TITLE
Explore a namespaces config

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -18,6 +18,12 @@ public struct YPImagePickerConfiguration {
     
     public init() {}
     
+    // Library configuration
+    public var library = YPConfigLibrary()
+    
+    // Video configuration
+    public var video = YPConfigVideo()
+    
     /// Use this property to modify the default wordings provided.
     public var wordings = YPWordings()
     
@@ -27,26 +33,8 @@ public struct YPImagePickerConfiguration {
     /// Use this property to modify the default colors provided.
     public var colors = YPColors()
     
-    /// Set this to true if you want to force the library output to be a squared image. Defaults to false
-    @available(*, obsoleted: 3.0.0, renamed: "onlySquareFromLibrary")
-    public var onlySquareImagesFromLibrary = false
-    
-    /// Set this to true if you want to force the library output to be a squared image. Defaults to false
-    public var onlySquareFromLibrary = false
-    
     /// Set this to true if you want to force the camera output to be a squared image. Defaults to true
     public var onlySquareImagesFromCamera = true
-    
-    /// Ex: cappedTo:1024 will make sure images from the library will be
-    /// resized to fit in a 1024x1024 box. Defaults to original image size.
-    public var libraryTargetImageSize = YPLibraryImageSize.original
-    
-    /// Enables videos within the library. Defaults to false
-    @available(*, obsoleted: 3.0.0, renamed: "libraryMediaType")
-    public var showsVideoInLibrary = false
-    
-    /// Choose what media types are available in the library. Defaults to `.photo`
-    public var libraryMediaType = YPlibraryMediaType.photo
     
     /// Enables selecting the front camera by default, useful for avatars. Defaults to false
     public var usesFrontCamera = false
@@ -57,12 +45,6 @@ public struct YPImagePickerConfiguration {
     /// Enables you to opt out from saving new (or old but filtered) images to the
     /// user's photo library. Defaults to true.
     public var shouldSaveNewPicturesToAlbum = true
-    
-    /// Choose the videoCompression.  Defaults to AVAssetExportPresetHighestQuality
-    public var videoCompression: String = AVAssetExportPresetHighestQuality
-    
-    /// Choose the result video extension if you trim or compress a video. Defaults to mov.
-    public var videoExtension: AVFileType = .mov
     
     /// Defines the name of the album when saving pictures in the user's photo library.
     /// In general that would be your App name. Defaults to "DefaultYPImagePickerAlbumName"
@@ -75,32 +57,10 @@ public struct YPImagePickerConfiguration {
     /// Defines which screens are shown at launch, and their order.
     /// Default value is `[.library, .photo]`
     public var screens: [YPPickerScreen] = [.library, .photo]
-    
-    /// Defines the time limit for recording videos.
-    /// Default is 30 seconds.
-    public var videoRecordingTimeLimit: TimeInterval = 60.0
-    
-    /// Defines the time limit for videos from the library.
-    /// Defaults to 60 seconds.
-    public var videoFromLibraryTimeLimit: TimeInterval = 60.0
-    
-    /// Defines the minimum time for the video
-    /// Defaults to 3 seconds.
-    public var videoMinimumTimeLimit: TimeInterval = 3.0
-    
-    /// The maximum duration allowed for the trimming. Change it before setting the asset, as the asset preview
-    public var trimmerMaxDuration: Double = 60.0
-    
-    /// The minimum duration allowed for the trimming.
-    /// The handles won't pan further if the minimum duration is attained.
-    public var trimmerMinDuration: Double = 3.0
 
     /// Adds a Crop step in the photo taking process, after filters.  Defaults to .none
     public var showsCrop: YPCropType = .none
     
-    /// Anything superior than 1 will enable the multiple selection feature.
-    public var maxNumberOfItems = 1
-
     /// Adds a Overlay View to the camera
     public var overlayView = UIView()
     
@@ -120,6 +80,94 @@ public struct YPImagePickerConfiguration {
         YPFilterDescriptor(name: "Instant", filterName: "CIPhotoEffectInstant"),
         YPFilterDescriptor(name: "Sepia", filterName: "CISepiaTone")
     ]
+    
+    /// Migration
+    
+    @available(*, obsoleted: 3.0.0, renamed: "video.compression")
+    public var videoCompression: String = AVAssetExportPresetHighestQuality
+    
+    @available(*, obsoleted: 3.0.0, renamed: "video.fileType")
+    public var videoExtension: AVFileType = .mov
+    
+    @available(*, obsoleted: 3.0.0, renamed: "video.recordingTimeLimit")
+    public var videoRecordingTimeLimit: TimeInterval = 60.0
+    
+    @available(*, obsoleted: 3.0.0, renamed: "video.libraryTimeLimit")
+    public var videoFromLibraryTimeLimit: TimeInterval = 60.0
+    
+    @available(*, obsoleted: 3.0.0, renamed: "video.minimumTimeLimit")
+    public var videoMinimumTimeLimit: TimeInterval = 3.0
+    
+    @available(*, obsoleted: 3.0.0, renamed: "video.trimmerMaxDuration")
+    public var trimmerMaxDuration: Double = 60.0
+
+    @available(*, obsoleted: 3.0.0, renamed: "video.trimmerMinDuration")
+    public var trimmerMinDuration: Double = 3.0
+    
+    @available(*, obsoleted: 3.0.0, renamed: "library.onlySquare")
+    public var onlySquareImagesFromLibrary = false
+    
+    @available(*, obsoleted: 3.0.0, renamed: "library.onlySquare")
+    public var onlySquareFromLibrary = false
+    
+    @available(*, obsoleted: 3.0.0, renamed: "library.targetImageSize")
+    public var libraryTargetImageSize = YPLibraryImageSize.original
+    
+    @available(*, obsoleted: 3.0.0, renamed: "library.mediaType")
+    public var showsVideoInLibrary = false
+    
+    @available(*, obsoleted: 3.0.0, renamed: "library.mediaType")
+    public var libraryMediaType = YPlibraryMediaType.photo
+    
+    @available(*, obsoleted: 3.0.0, renamed: "library.maxNumberOfItems")
+    public var maxNumberOfItems = 1
+    
+}
+
+/// Encapsulates library specific settings.
+public struct YPConfigLibrary {
+    
+    /// Set this to true if you want to force the library output to be a squared image. Defaults to false
+    public var onlySquare = false
+    
+    /// Ex: cappedTo:1024 will make sure images from the library will be
+    /// resized to fit in a 1024x1024 box. Defaults to original image size.
+    public var targetImageSize = YPLibraryImageSize.original
+    
+    /// Choose what media types are available in the library. Defaults to `.photo`
+    public var mediaType = YPlibraryMediaType.photo
+    
+    /// Anything superior than 1 will enable the multiple selection feature.
+    public var maxNumberOfItems = 1
+}
+
+/// Encapsulates video specific settings.
+public struct YPConfigVideo {
+    
+    /// Choose the videoCompression.  Defaults to AVAssetExportPresetHighestQuality
+    public var compression: String = AVAssetExportPresetHighestQuality
+    
+    /// Choose the result video extension if you trim or compress a video. Defaults to mov.
+    public var fileType: AVFileType = .mov
+    
+    /// Defines the time limit for recording videos.
+    /// Default is 60 seconds.
+    public var recordingTimeLimit: TimeInterval = 60.0
+    
+    /// Defines the time limit for videos from the library.
+    /// Defaults to 60 seconds.
+    public var libraryTimeLimit: TimeInterval = 60.0
+    
+    /// Defines the minimum time for the video
+    /// Defaults to 3 seconds.
+    public var minimumTimeLimit: TimeInterval = 3.0
+    
+    /// The maximum duration allowed for the trimming. Change it before setting the asset, as the asset preview
+    public var trimmerMaxDuration: Double = 60.0
+    
+    /// The minimum duration allowed for the trimming.
+    /// The handles won't pan further if the minimum duration is attained.
+    public var trimmerMinDuration: Double = 3.0
 }
 
 public enum YPlibraryMediaType {

--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -49,8 +49,8 @@ public class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
         trimmerView.mainColor = YPConfig.colors.trimmerMainColor
         trimmerView.handleColor = YPConfig.colors.trimmerHandleColor
         trimmerView.positionBarColor = YPConfig.colors.positionLineColor
-        trimmerView.maxDuration = YPConfig.trimmerMaxDuration
-        trimmerView.minDuration = YPConfig.trimmerMinDuration
+        trimmerView.maxDuration = YPConfig.video.trimmerMaxDuration
+        trimmerView.minDuration = YPConfig.video.trimmerMinDuration
         
         coverThumbSelectorView.thumbBorderColor = YPConfig.colors.coverSelectorBorderColor
         
@@ -125,7 +125,7 @@ public class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
             // Looks like file:///private/var/mobile/Containers/Data/Application
             // /FAD486B4-784D-4397-B00C-AD0EFFB45F52/tmp/8A2B410A-BD34-4E3F-8CB5-A548A946C1F1.mov
             let destinationURL = URL(fileURLWithPath: NSTemporaryDirectory())
-                .appendingUniquePathComponent(pathExtension: YPConfig.videoExtension.fileExtension)
+                .appendingUniquePathComponent(pathExtension: YPConfig.video.fileType.fileExtension)
             
             try trimmedAsset.export(to: destinationURL) { [weak self] in
                 guard let weakSelf = self else { return }

--- a/Source/Helpers/Extensions/AVAsset+Extensions.swift
+++ b/Source/Helpers/Extensions/AVAsset+Extensions.swift
@@ -46,7 +46,7 @@ extension AVAsset {
         }
         
         exportSession.outputURL = destination
-        exportSession.outputFileType = YPConfig.videoExtension
+        exportSession.outputFileType = YPConfig.video.fileType
         exportSession.shouldOptimizeForNetworkUse = true
         exportSession.videoComposition = videoComposition
         

--- a/Source/Helpers/Extensions/AVFoundation+Extensions.swift
+++ b/Source/Helpers/Extensions/AVFoundation+Extensions.swift
@@ -32,7 +32,7 @@ public func createVideoItem(videoURL: URL,
             let asset = AVURLAsset(url: videoURL)
             
             let exportSession = AVAssetExportSession(asset: asset,
-                                                     presetName: YPConfig.videoCompression)
+                                                     presetName: YPConfig.video.compression)
             exportSession?.outputURL = uploadURL
             exportSession?.outputFileType = AVFileType.mov
             exportSession?.shouldOptimizeForNetworkUse = true

--- a/Source/Helpers/YPAlerts.swift
+++ b/Source/Helpers/YPAlerts.swift
@@ -11,7 +11,7 @@ import UIKit
 struct YPAlert {
     static func videoTooLongAlert() -> UIAlertController {
         let msg = String(format: YPConfig.wordings.videoDurationPopup.tooLongMessage,
-                         "\(YPConfig.videoFromLibraryTimeLimit)")
+                         "\(YPConfig.video.libraryTimeLimit)")
         let alert = UIAlertController(title: YPConfig.wordings.videoDurationPopup.title,
                                       message: msg,
                                       preferredStyle: .actionSheet)
@@ -21,7 +21,7 @@ struct YPAlert {
     
     static func videoTooShortAlert() -> UIAlertController {
         let msg = String(format: YPConfig.wordings.videoDurationPopup.tooShortMessage,
-                         "\(YPConfig.videoMinimumTimeLimit)")
+                         "\(YPConfig.video.minimumTimeLimit)")
         let alert = UIAlertController(title: YPConfig.wordings.videoDurationPopup.title,
                                       message: msg,
                                       preferredStyle: .actionSheet)

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -118,12 +118,12 @@ class LibraryMediaManager {
                 // 5. Configuring export session
                 
                 let exportSession = AVAssetExportSession(asset: assetComposition,
-                                                         presetName: YPConfig.videoCompression)
-                exportSession?.outputFileType = YPConfig.videoExtension
+                                                         presetName: YPConfig.video.compression)
+                exportSession?.outputFileType = YPConfig.video.fileType
                 exportSession?.shouldOptimizeForNetworkUse = true
                 exportSession?.videoComposition = videoComposition
                 exportSession?.outputURL = URL(fileURLWithPath: NSTemporaryDirectory())
-                    .appendingUniquePathComponent(pathExtension: YPConfig.videoExtension.fileExtension)
+                    .appendingUniquePathComponent(pathExtension: YPConfig.video.fileType.fileExtension)
                 
                 // 6. Exporting
                 

--- a/Source/Pages/Gallery/YPAlbumsManager.swift
+++ b/Source/Pages/Gallery/YPAlbumsManager.swift
@@ -55,7 +55,7 @@ class YPAlbumsManager {
                     }
                     album.collection = assetCollection
                     
-                    if YPConfig.libraryMediaType == .photo {
+                    if YPConfig.library.mediaType == .photo {
                         if !(assetCollection.assetCollectionSubtype == .smartAlbumSlomoVideos
                             || assetCollection.assetCollectionSubtype == .smartAlbumVideos) {
                             albums.append(album)
@@ -72,7 +72,7 @@ class YPAlbumsManager {
     
     func mediaCountFor(collection: PHAssetCollection) -> Int {
         let options = PHFetchOptions()
-        options.predicate = YPConfig.libraryMediaType.predicate()
+        options.predicate = YPConfig.library.mediaType.predicate()
         let result = PHAsset.fetchAssets(in: collection, options: options)
         return result.count
     }

--- a/Source/Pages/Gallery/YPAssetViewContainer.swift
+++ b/Source/Pages/Gallery/YPAssetViewContainer.swift
@@ -19,7 +19,7 @@ class YPAssetViewContainer: UIView {
     public let spinnerView = UIView()
     public let squareCropButton = UIButton()
     public let multipleSelectionButton = UIButton()
-    public var onlySquare = YPConfig.onlySquareFromLibrary
+    public var onlySquare = YPConfig.library.onlySquare
     public var isShown = true
     
     private let spinner = UIActivityIndicatorView(activityIndicatorStyle: .white)

--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -73,7 +73,7 @@ final class YPAssetZoomableView: UIScrollView {
             self.setAssetFrame(for: self.videoView, with: preview)
             
             // Fit video view if only squared
-            if YPConfig.onlySquareFromLibrary {
+            if YPConfig.library.onlySquare {
                 self.fitImage(true)
             }
             
@@ -113,7 +113,7 @@ final class YPAssetZoomableView: UIScrollView {
             self.setAssetFrame(for: self.photoImageView, with: image)
             
             // Fit image if only squared
-            if YPConfig.onlySquareFromLibrary {
+            if YPConfig.library.onlySquare {
                 self.fitImage(true)
             }
             
@@ -224,7 +224,7 @@ extension YPAssetZoomableView: UIScrollViewDelegate {
         guard let view = view, view == photoImageView || view == videoView else { return }
         
         // prevent to zoom out
-        if YPConfig.onlySquareFromLibrary && scale < squaredZoomScale {
+        if YPConfig.library.onlySquare && scale < squaredZoomScale {
             self.fitImage(true, animated: true)
         }
         

--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension YPLibraryVC {
-    var isLimitExceeded: Bool { return selection.count >= YPConfig.maxNumberOfItems }
+    var isLimitExceeded: Bool { return selection.count >= YPConfig.library.maxNumberOfItems }
     
     func setupCollectionView() {
         v.collectionView.dataSource = self
@@ -24,7 +24,7 @@ extension YPLibraryVC {
     
     /// When tapping on the cell with long press, clear all previously selected cells.
     @objc func handleLongPress(longPressGR: UILongPressGestureRecognizer) {
-        if multipleSelectionEnabled || isProcessing || YPConfig.maxNumberOfItems <= 1 {
+        if multipleSelectionEnabled || isProcessing || YPConfig.library.maxNumberOfItems <= 1 {
             return
         }
         

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -61,8 +61,8 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         registerForTapOnPreview()
         refreshMediaRequest()
         
-        v.assetViewContainer.multipleSelectionButton.isHidden = !(YPConfig.maxNumberOfItems > 1)
-        v.maxNumberWarningLabel.text = String(format: YPConfig.wordings.warningMaxItemsLimit, YPConfig.maxNumberOfItems)
+        v.assetViewContainer.multipleSelectionButton.isHidden = !(YPConfig.library.maxNumberOfItems > 1)
+        v.maxNumberWarningLabel.text = String(format: YPConfig.wordings.warningMaxItemsLimit, YPConfig.library.maxNumberOfItems)
     }
     
     // MARK: - View Lifecycle
@@ -100,7 +100,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         // Forces assetZoomableView to have a contentSize.
         // otherwise 0 in first selection triggering the bug : "invalid image size 0x0"
         // Also fits the first element to the square if the onlySquareFromLibrary = true
-        if !YPConfig.onlySquareFromLibrary && v.assetZoomableView.contentSize == CGSize(width: 0, height: 0) {
+        if !YPConfig.library.onlySquare && v.assetZoomableView.contentSize == CGSize(width: 0, height: 0) {
             v.assetZoomableView.setZoomScale(1, animated: false)
         }
     }
@@ -230,7 +230,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         // Sorting condition
         let options = PHFetchOptions()
         options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-        options.predicate = YPConfig.libraryMediaType.predicate()
+        options.predicate = YPConfig.library.mediaType.predicate()
         return options
     }
     
@@ -285,8 +285,8 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             return true
         }
         
-        let tooLong = asset.duration > YPConfig.videoFromLibraryTimeLimit
-        let tooShort = asset.duration < YPConfig.videoMinimumTimeLimit
+        let tooLong = asset.duration > YPConfig.video.libraryTimeLimit
+        let tooShort = asset.duration < YPConfig.video.minimumTimeLimit
         
         if tooLong || tooShort {
             DispatchQueue.main.async {
@@ -450,7 +450,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
     
     // Reduce image size further if needed libraryTargetImageSize is capped.
     func resizedImageIfNeeded(image: UIImage) -> UIImage {
-        if case let YPLibraryImageSize.cappedTo(size: capped) = YPConfig.libraryTargetImageSize {
+        if case let YPLibraryImageSize.cappedTo(size: capped) = YPConfig.library.targetImageSize {
             let size = cappedSize(for: image.size, cappedAt: capped)
             if let resizedImage = image.resized(to: size) {
                 return resizedImage

--- a/Source/Pages/Video/YPVideoVC.swift
+++ b/Source/Pages/Video/YPVideoVC.swift
@@ -25,7 +25,7 @@ public class YPVideoVC: UIViewController, YPPermissionCheckable {
         super.init(nibName: nil, bundle: nil)
         title = YPConfig.wordings.videoTitle
         
-        videoHelper.initialize(withVideoRecordingLimit: YPConfig.videoRecordingTimeLimit)
+        videoHelper.initialize(withVideoRecordingLimit: YPConfig.video.recordingTimeLimit)
         
         videoHelper.didCaptureVideo = { [weak self] videoURL in
             self?.didCaptureVideo?(videoURL)

--- a/YPImagePickerExample/YPImagePickerExample/ViewController.swift
+++ b/YPImagePickerExample/YPImagePickerExample/ViewController.swift
@@ -68,17 +68,17 @@ class ViewController: UIViewController {
         // Uncomment and play around with the configuration 👨‍🔬 🚀
 
 //        /// Set this to true if you want to force the  library output to be a squared image. Defaults to false
-//        config.onlySquareFromLibrary = true
+//        config.library.onlySquare = true
 //
 //        /// Set this to true if you want to force the camera output to be a squared image. Defaults to true
 //        config.onlySquareImagesFromCamera = false
 //
 //        /// Ex: cappedTo:1024 will make sure images from the library will be
 //        /// resized to fit in a 1024x1024 box. Defaults to original image size.
-//        config.libraryTargetImageSize = .cappedTo(size: 1024)
+//        config.library.targetImageSize = .cappedTo(size: 1024)
 //
 //        /// Choose what media types are available in the library. Defaults to `.photo`
-        config.libraryMediaType = .photoAndVideo
+        config.library.mediaType = .photoAndVideo
 //
 //        /// Enables selecting the front camera by default, useful for avatars. Defaults to false
 //        config.usesFrontCamera = true
@@ -97,7 +97,9 @@ class ViewController: UIViewController {
         config.shouldSaveNewPicturesToAlbum = false
 //
 //        /// Choose the videoCompression.  Defaults to AVAssetExportPresetHighestQuality
-//        config.videoCompression = AVAssetExportPreset640x480
+        config.video.fileType = .m4a
+        
+        
 //
 //        /// Defines the name of the album when saving pictures in the user's photo library.
 //        /// In general that would be your App name. Defaults to "DefaultYPImagePickerAlbumName"
@@ -114,11 +116,11 @@ class ViewController: UIViewController {
 //
 //        /// Defines the time limit for recording videos.
 //        /// Default is 30 seconds.
-//        config.videoRecordingTimeLimit = 5.0
+//        config.video.recordingTimeLimit = 5.0
 //
 //        /// Defines the time limit for videos from the library.
 //        /// Defaults to 60 seconds.
-        config.videoFromLibraryTimeLimit = 500.0
+        config.video.libraryTimeLimit = 500.0
 //
 //        /// Adds a Crop step in the photo taking process, after filters. Defaults to .none
         config.showsCrop = .rectangle(ratio: (16/9))
@@ -136,7 +138,7 @@ class ViewController: UIViewController {
         /// Defines if the status bar should be hidden when showing the picker. Default is true
         config.hidesStatusBar = false
 
-        config.maxNumberOfItems = 5
+        config.library.maxNumberOfItems = 5
 
         // Here we use a per picker configuration. Configuration is always shared.
         // That means than when you create one picker with configuration, than you can create other picker with just


### PR DESCRIPTION
I have been willing to try this out for quite some time 👨‍🔬 

The rationale is that our config file grew quite a bit with the features and it can now be quite challenging to find what you want in there.

I believe splitting it per functionality would make it easier to use, and would also separate the code a little better.

```swift
var config = YPImagePickerConfiguration()
config.screens = [.library, .photo, .video]
config.videoCompression = AVAssetExportPreset960x540
config.videoRecordingTimeLimit = 10
config.libraryTargetImageSize = .cappedTo(size: 2048)
config.libraryMediaType = .photoAndVideo
``` 
would become
```swift
var config = YPImagePickerConfiguration()
config.screens = [.library, .photo, .video]
config.video.compression = AVAssetExportPreset960x540
config.video. recordingTimeLimit = 10
config.library.targetImageSize = .cappedTo(size: 2048)
config.library.mediaType = .photoAndVideo
``` 

@NikKovIos 
Looking forward to know your thoughts! 

PS: This comes with the migration out of the box so that users would just have to click on Xcode's `fixit` :)