### PR TITLE
Fixes double dismiss

### DIFF
--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -274,9 +274,7 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     
     @objc
     func close() {
-        dismiss(animated: true) {
-            self.didClose?()
-        }
+        self.didClose?()
     }
     
     // When pressing "Next"


### PR DESCRIPTION
This is addressing  https://github.com/Yummypets/YPImagePicker/issues/113

We had our code explicitly dismissing when it should be the user's job.
Actually with the example given below in our sample code, `dismiss` was actually called twice.

```swift
// Single Photo implementation.
picker.didFinishPicking { items, _ in
    self.selectedItems = items
    self.selectedImageV.image = items.singlePhoto?.image
    picker.dismiss(animated: true, completion: nil)
}
```

Removing the dismiss inside the library will enable users to call `animated: false` for example as @WeDrinkInAssembly suggested.



