### PR TITLE
Enables Disabling scroll to pan between modes

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -18,6 +18,9 @@ public struct YPImagePickerConfiguration {
     
     public init() {}
     
+    /// Scroll to change modes, defaults to true
+    public var isScrollToChangeModesEnabled = true
+    
     // Library configuration
     public var library = YPConfigLibrary()
     

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -320,7 +320,7 @@ extension YPPickerVC: YPLibraryViewDelegate {
     public func libraryViewFinishedLoading() {
         libraryVC?.isProcessing = false
         DispatchQueue.main.async {
-            self.v.scrollView.isScrollEnabled = true
+            self.v.scrollView.isScrollEnabled = YPConfig.isScrollToChangeModesEnabled
             self.libraryVC?.v.hideLoader()
             self.updateUI()
         }

--- a/YPImagePickerExample/YPImagePickerExample/ExampleViewController.swift
+++ b/YPImagePickerExample/YPImagePickerExample/ExampleViewController.swift
@@ -138,6 +138,9 @@ class ExampleViewController: UIViewController {
 
         config.library.maxNumberOfItems = 5
         
+        /* Disable scroll to change between mode */
+        // config.isScrollToChangeModesEnabled = false
+        
         /* Skip selection gallery after multiple selections */
         // config.library.skipSelectionsGallery = true
 


### PR DESCRIPTION
@boboxiaodd @NikKovIos 
https://github.com/Yummypets/YPImagePicker/issues/148#issuecomment-397206799
Introduces `isScrollToChangeModesEnabled` in config. `false` will disable panning between modes 