### PR TITLE
Fixes warning in #81

### DIFF
--- a/Source/Helpers/Extensions/PHCachingImageManager+Extensions.swift
+++ b/Source/Helpers/Extensions/PHCachingImageManager+Extensions.swift
@@ -88,7 +88,7 @@ extension PHCachingImageManager {
         options.isNetworkAccessAllowed = true
         options.isSynchronous = true
         requestImage(for: asset,
-                     targetSize: CGSize(width: asset.pixelWidth, height: asset.pixelHeight),
+                     targetSize: PHImageManagerMaximumSize,
                      contentMode: .aspectFill,
                      options: options) { result, info in
                         guard let image = result else {


### PR DESCRIPTION
After some debugging I found that replacing
`CGSize(width: asset.pixelWidth, height: asset.pixelHeight)`
by
`PHImageManagerMaximumSize`
removes the warning log 🎉 in requestImage call in PHCachingImageManager+Extensions

Woop Woop!