### PR TITLE
Weak instead of unowned

### DIFF
--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -58,28 +58,31 @@ final class YPAssetZoomableView: UIScrollView {
                          mediaManager: LibraryMediaManager,
                          storedCropPosition: YPLibrarySelection?,
                          completion: @escaping () -> Void) {
-        mediaManager.imageManager?.fetchPreviewFor(video: video) { [unowned self] preview in
-            self.isVideoMode = true
-            self.photoImageView.removeFromSuperview()
+        mediaManager.imageManager?.fetchPreviewFor(video: video) { [weak self] preview in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.isVideoMode = true
+            strongSelf.photoImageView.removeFromSuperview()
             
-            if self.videoView.isDescendant(of: self) == false {
-                self.addSubview(self.videoView)
+            if strongSelf.videoView.isDescendant(of: strongSelf) == false {
+                strongSelf.addSubview(strongSelf.videoView)
             }
             
-            self.setZoomScale(1, animated: false)
+            strongSelf.setZoomScale(1, animated: false)
             
-            self.videoView.setPreviewImage(preview)
+            strongSelf.videoView.setPreviewImage(preview)
             
-            self.setAssetFrame(for: self.videoView, with: preview)
+            strongSelf.setAssetFrame(for: strongSelf.videoView, with: preview)
             
             // Fit video view if only squared
             if YPConfig.library.onlySquare {
-                self.fitImage(true)
+                strongSelf.fitImage(true)
             }
             
             // Stored crop position in multiple selection
             if let scp = storedCropPosition {
-                self.applyStoredCropPosition(scp)
+                strongSelf.applyStoredCropPosition(scp)
             }
             
             completion()
@@ -94,32 +97,35 @@ final class YPAssetZoomableView: UIScrollView {
                          mediaManager: LibraryMediaManager,
                          storedCropPosition: YPLibrarySelection?,
                          completion: @escaping () -> Void) {
-        mediaManager.imageManager?.fetch(photo: photo) { [unowned self] image, _ in
-            self.isVideoMode = false
-            self.videoView.showPlayImage(show: false)
-            self.videoView.removeFromSuperview()
-            self.videoView.deallocate()
+        mediaManager.imageManager?.fetch(photo: photo) { [weak self] image, _ in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.isVideoMode = false
+            strongSelf.videoView.showPlayImage(show: false)
+            strongSelf.videoView.removeFromSuperview()
+            strongSelf.videoView.deallocate()
             
-            if self.photoImageView.isDescendant(of: self) == false {
-                self.addSubview(self.photoImageView)
+            if strongSelf.photoImageView.isDescendant(of: strongSelf) == false {
+                strongSelf.addSubview(strongSelf.photoImageView)
             }
             
-            self.setZoomScale(1, animated: false)
+            strongSelf.setZoomScale(1, animated: false)
             
-            self.photoImageView.image = image
-            self.photoImageView.contentMode = .scaleAspectFill
-            self.photoImageView.clipsToBounds = true
+            strongSelf.photoImageView.image = image
+            strongSelf.photoImageView.contentMode = .scaleAspectFill
+            strongSelf.photoImageView.clipsToBounds = true
             
-            self.setAssetFrame(for: self.photoImageView, with: image)
+            strongSelf.setAssetFrame(for: strongSelf.photoImageView, with: image)
             
             // Fit image if only squared
             if YPConfig.library.onlySquare {
-                self.fitImage(true)
+                strongSelf.fitImage(true)
             }
             
             // Stored crop position in multiple selection
             if let scp = storedCropPosition {
-                self.applyStoredCropPosition(scp)
+                strongSelf.applyStoredCropPosition(scp)
             }
 
             completion()

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -78,9 +78,12 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         // When crop area changes in multiple selection mode,
         // we need to update the scrollView values in order to restore
         // them when user selects a previously selected item.
-        v.assetZoomableView.cropAreaDidChange = { [unowned self] in
-            if self.multipleSelectionEnabled {
-                self.updateCropInfo()
+        v.assetZoomableView.cropAreaDidChange = { [weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+            if strongSelf.multipleSelectionEnabled {
+                strongSelf.updateCropInfo()
             }
         }
     }
@@ -185,10 +188,13 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
     }
     
     func checkPermission() {
-        checkPermissionToAccessPhotoLibrary { [unowned self] hasPermission in
-            if hasPermission && !self.initialized {
-                self.initialize()
-                self.initialized = true
+        checkPermissionToAccessPhotoLibrary { [weak self] hasPermission in
+            guard let strongSelf = self else {
+                return
+            }
+            if hasPermission && !strongSelf.initialized {
+                strongSelf.initialize()
+                strongSelf.initialized = true
             }
         }
     }

--- a/Source/Pages/Photo/YPPhotoCaptureDefaults.swift
+++ b/Source/Pages/Photo/YPPhotoCaptureDefaults.swift
@@ -38,11 +38,14 @@ extension YPPhotoCapture {
     
     func start(with previewView: UIView, completion: @escaping () -> Void) {
         self.previewView = previewView
-        sessionQueue.async { [unowned self] in
-            if !self.isCaptureSessionSetup {
-                self.setupCaptureSession()
+        sessionQueue.async { [weak self] in
+            guard let strongSelf = self else {
+                return
             }
-            self.startCamera(completion: {
+            if !strongSelf.isCaptureSessionSetup {
+                strongSelf.setupCaptureSession()
+            }
+            strongSelf.startCamera(completion: {
                 completion()
             })
         }

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -73,7 +73,7 @@ public class YPImagePicker: UINavigationController {
         setupLoadingView()
         navigationBar.isTranslucent = false
 
-        picker.didSelectItems = { [unowned self] items in
+        picker.didSelectItems = { [weak self] items in
             let showsFilters = YPConfig.showsFilters
             
             // Use Fade transition instead of default push animation
@@ -81,18 +81,18 @@ public class YPImagePicker: UINavigationController {
             transition.duration = 0.3
             transition.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
             transition.type = kCATransitionFade
-            self.view.layer.add(transition, forKey: nil)
+            self?.view.layer.add(transition, forKey: nil)
             
             // Multiple items flow
             if items.count > 1 {
                 if YPConfig.library.skipSelectionsGallery {
-                    self.didSelect(items: items)
+                    self?.didSelect(items: items)
                     return
                 } else {
                     let selectionsGalleryVC = YPSelectionsGalleryVC(items: items) { _, items in
-                        self.didSelect(items: items)
+                        self?.didSelect(items: items)
                     }
-                    self.pushViewController(selectionsGalleryVC, animated: true)
+                    self?.pushViewController(selectionsGalleryVC, animated: true)
                     return
                 }
             }
@@ -110,7 +110,7 @@ public class YPImagePicker: UINavigationController {
                             YPPhotoSaver.trySaveImage(photo.image, inAlbumNamed: YPConfig.albumName)
                         }
                     }
-                    self.didSelect(items: [mediaItem])
+                    self?.didSelect(items: [mediaItem])
                 }
                 
                 func showCropVC(photo: YPMediaPhoto, completion: @escaping (_ aphoto: YPMediaPhoto) -> Void) {
@@ -120,7 +120,7 @@ public class YPImagePicker: UINavigationController {
                             photo.modifiedImage = croppedImage
                             completion(photo)
                         }
-                        self.pushViewController(cropVC, animated: true)
+                        self?.pushViewController(cropVC, animated: true)
                     } else {
                         completion(photo)
                     }
@@ -135,7 +135,7 @@ public class YPImagePicker: UINavigationController {
                             showCropVC(photo: outputPhoto, completion: completion)
                         }
                     }
-                    self.pushViewController(filterVC, animated: false)
+                    self?.pushViewController(filterVC, animated: false)
                 } else {
                     showCropVC(photo: photo, completion: completion)
                 }
@@ -143,12 +143,12 @@ public class YPImagePicker: UINavigationController {
                 if showsFilters {
                     let videoFiltersVC = YPVideoFiltersVC.initWith(video: video,
                                                                    isFromSelectionVC: false)
-                    videoFiltersVC.didSave = { [unowned self] outputMedia in
-                        self.didSelect(items: [outputMedia])
+                    videoFiltersVC.didSave = { [weak self] outputMedia in
+                        self?.didSelect(items: [outputMedia])
                     }
-                    self.pushViewController(videoFiltersVC, animated: true)
+                    self?.pushViewController(videoFiltersVC, animated: true)
                 } else {
-                    self.didSelect(items: [YPMediaItem.video(v: video)])
+                    self?.didSelect(items: [YPMediaItem.video(v: video)])
                 }
             }
         }

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -58,8 +58,8 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         // Camera
         if YPConfig.screens.contains(.photo) {
             cameraVC = YPCameraVC()
-            cameraVC?.didCapturePhoto = { [unowned self] img in
-                self.didSelectItems?([YPMediaItem.photo(p: YPMediaPhoto(image: img,
+            cameraVC?.didCapturePhoto = { [weak self] img in
+                self?.didSelectItems?([YPMediaItem.photo(p: YPMediaPhoto(image: img,
                                                                         fromCamera: true))])
             }
         }
@@ -67,8 +67,8 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         // Video
         if YPConfig.screens.contains(.video) {
             videoVC = YPVideoVC()
-            videoVC?.didCaptureVideo = { [unowned self] videoURL in
-                self.didSelectItems?([YPMediaItem
+            videoVC?.didCaptureVideo = { [weak self] videoURL in
+                self?.didSelectItems?([YPMediaItem
                     .video(v: YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
                                            videoURL: videoURL,
                                            fromCamera: true))])


### PR DESCRIPTION
To fix crashes when quickly opening and closing imagePicker views. Sometimes it crashes with SIGABRT error on referencing self.