### PR TITLE
Customize the number of items in the library collection view.

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -146,7 +146,13 @@ public struct YPConfigLibrary {
     /// Anything greater than 1 will desactivate live photo and video modes (library only) and
     // force users to select at least the number of items defined.
     public var minNumberOfItems = 1
-    
+
+    /// Set the number of items per row in collection view. Defaults to 4.
+    public var numberOfItemsInRow: Int = 4
+
+    /// Set the spacing between items in collection view. Defaults to 1.0.
+    public var spacingBetweenItems: CGFloat = 1.0
+
     /// Allow to skip the selections gallery when selecting the multiple media items. Defaults to false.
     public var skipSelectionsGallery = false
 }

--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -185,11 +185,19 @@ extension YPLibraryVC: UICollectionViewDelegate {
 }
 
 extension YPLibraryVC: UICollectionViewDelegateFlowLayout {
-    
     public func collectionView(_ collectionView: UICollectionView,
                                layout collectionViewLayout: UICollectionViewLayout,
                                sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width = (collectionView.frame.width - 3) / 4
+        let margins = YPConfig.library.spacingBetweenItems * CGFloat(YPConfig.library.numberOfItemsInRow - 1)
+        let width = (collectionView.frame.width - margins) / CGFloat(YPConfig.library.numberOfItemsInRow)
         return CGSize(width: width, height: width)
+    }
+
+    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return YPConfig.library.spacingBetweenItems
+    }
+
+    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return YPConfig.library.spacingBetweenItems
     }
 }


### PR DESCRIPTION
Hi.
I've added the following configurations for more flexible layouts.

- `YPConfig.library.numberOfItemsInRow` : the number of items per row in collection view. Defaults to 4.
- `YPConfig.library.spacingBetweenItems` : the spacing between items in collection view. Defaults to 1.0.