### PR TITLE
Make the library collection view always bounce vertically

### DIFF
--- a/Source/Pages/Gallery/YPLibraryView.xib
+++ b/Source/Pages/Gallery/YPLibraryView.xib
@@ -19,7 +19,7 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Cu-Zp-X0j">
                     <rect key="frame" x="0.0" y="0.0" width="400" height="550"/>
                     <subviews>
-                        <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="6id-Ro-HHC">
+                        <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="6id-Ro-HHC">
                             <rect key="frame" x="0.0" y="400" width="400" height="150"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="1" minimumInteritemSpacing="1" id="jnu-mn-3OB">


### PR DESCRIPTION
**Issue**
Asset view never closes down without enough items because the library collection view does not bounce.

**Solution**
Make the library collection view always bounce vertically.