### PR TITLE
Different hotfixes

### DIFF
--- a/Source/BottomPager/YPBottomPagerView.swift
+++ b/Source/BottomPager/YPBottomPagerView.swift
@@ -27,7 +27,7 @@ final class YPBottomPagerView: UIView {
             0,
             |scrollView|,
             0,
-            |header| ~ 50
+            |header| ~ 44
         )
         
         if #available(iOS 11.0, *) {

--- a/Source/BottomPager/YPMenuItem.swift
+++ b/Source/BottomPager/YPMenuItem.swift
@@ -37,12 +37,15 @@ final class YPMenuItem: UIView {
         )
         
         textLabel.centerInContainer()
+        |-(10)-textLabel-(10)-|
         button.fillContainer()
         
         textLabel.style { l in
             l.textAlignment = .center
             l.font = UIFont.systemFont(ofSize: 17, weight: UIFont.Weight.medium)
             l.textColor = self.unselectedColor()
+            l.adjustsFontSizeToFitWidth = true
+            l.numberOfLines = 2
         }
     }
     

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -144,6 +144,9 @@ public struct YPConfigLibrary {
     /// Set this to true if you want to force the library output to be a squared image. Defaults to false
     public var onlySquare = false
     
+    /// Minimum width, to prevent selectiong too high images. Have sense if onlySquare is true and the image is portrait.
+    public var minWidthForItem: CGFloat?
+    
     /// Choose what media types are available in the library. Defaults to `.photo`
     public var mediaType = YPlibraryMediaType.photo
     

--- a/Source/Filters/Video/YPVideoFiltersVC.xib
+++ b/Source/Filters/Video/YPVideoFiltersVC.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -45,7 +45,7 @@
                         <constraint firstAttribute="width" secondItem="AFl-Bk-oPH" secondAttribute="height" multiplier="1:1" id="tL6-cM-ei5"/>
                     </constraints>
                 </view>
-                <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="daH-No-sZc">
+                <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="daH-No-sZc">
                     <rect key="frame" x="0.0" y="20" width="375" height="375"/>
                 </imageView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dMy-Fy-gyR">

--- a/Source/Filters/Video/YPVideoView.swift
+++ b/Source/Filters/Video/YPVideoView.swift
@@ -66,7 +66,6 @@ public class YPVideoView: UIView {
     override public func layoutSubviews() {
         super.layoutSubviews()
         playerLayer.frame = playerView.frame
-        previewImageView.frame = playerView.frame
     }
     
     @objc internal func singleTap() {

--- a/Source/Filters/YPFilter.swift
+++ b/Source/Filters/YPFilter.swift
@@ -98,7 +98,6 @@ extension YPFilter {
         let centerHeight = height / 2.0
         let radius0 = min(width / 4.0, height / 4.0)
         let radius1 = min(width / 1.5, height / 1.5)
-        print(width, height, centerWidth, centerHeight, radius0, radius1)
         
         let color0 = self.getColor(red: 128, green: 78, blue: 15, alpha: 255)
         let color1 = self.getColor(red: 79, green: 0, blue: 79, alpha: 255)

--- a/Source/Filters/YPFilter.swift
+++ b/Source/Filters/YPFilter.swift
@@ -9,25 +9,25 @@
 import UIKit
 import CoreImage
 
-typealias FilterApplierType = ((_ image: CIImage) -> CIImage?)
+public typealias FilterApplierType = ((_ image: CIImage) -> CIImage?)
 
 public struct YPFilter {
     var name = ""
     var applier: FilterApplierType?
     
-    init(name: String, coreImageFilterName: String) {
+    public init(name: String, coreImageFilterName: String) {
         self.name = name
         self.applier = YPFilter.coreImageFilter(name: coreImageFilterName)
     }
     
-    init(name: String, applier: FilterApplierType?) {
+    public init(name: String, applier: FilterApplierType?) {
         self.name = name
         self.applier = applier
     }
 }
 
 extension YPFilter {
-    static func coreImageFilter(name: String) -> FilterApplierType {
+    public static func coreImageFilter(name: String) -> FilterApplierType {
         return { (image: CIImage) -> CIImage? in
             let filter = CIFilter(name: name)
             filter?.setValue(image, forKey: kCIInputImageKey)
@@ -35,7 +35,7 @@ extension YPFilter {
         }
     }
     
-    static func clarendonFilter(foregroundImage: CIImage) -> CIImage? {
+    public static func clarendonFilter(foregroundImage: CIImage) -> CIImage? {
         let backgroundImage = getColorImage(red: 127, green: 187, blue: 227, alpha: Int(255 * 0.2), rect: foregroundImage.extent)
         return foregroundImage.applyingFilter("CIOverlayBlendMode", parameters: [
             "inputBackgroundImage": backgroundImage,
@@ -47,7 +47,7 @@ extension YPFilter {
                 ])
     }
     
-    static func nashvilleFilter(foregroundImage: CIImage) -> CIImage? {
+    public static func nashvilleFilter(foregroundImage: CIImage) -> CIImage? {
         let backgroundImage = getColorImage(red: 247, green: 176, blue: 153, alpha: Int(255 * 0.56), rect: foregroundImage.extent)
         let backgroundImage2 = getColorImage(red: 0, green: 70, blue: 150, alpha: Int(255 * 0.4), rect: foregroundImage.extent)
         return foregroundImage
@@ -67,7 +67,7 @@ extension YPFilter {
                 ])
     }
     
-    static func apply1977Filter(ciImage: CIImage) -> CIImage? {
+    public static func apply1977Filter(ciImage: CIImage) -> CIImage? {
         let filterImage = getColorImage(red: 243, green: 106, blue: 188, alpha: Int(255 * 0.1), rect: ciImage.extent)
         let backgroundImage = ciImage
             .applyingFilter("CIColorControls", parameters: [
@@ -91,7 +91,7 @@ extension YPFilter {
                 ])
     }
     
-    static func toasterFilter(ciImage: CIImage) -> CIImage? {
+    public static func toasterFilter(ciImage: CIImage) -> CIImage? {
         let width = ciImage.extent.width
         let height = ciImage.extent.height
         let centerWidth = width / 2.0
@@ -122,7 +122,7 @@ extension YPFilter {
     }
     
     
-    static func hazeRemovalFilter(image: CIImage) -> CIImage? {
+    public static func hazeRemovalFilter(image: CIImage) -> CIImage? {
         let filter = HazeRemovalFilter()
         filter.inputImage = image
         return filter.outputImage

--- a/Source/Filters/YPPhotoFiltersVC.swift
+++ b/Source/Filters/YPPhotoFiltersVC.swift
@@ -136,7 +136,7 @@ open class YPPhotoFiltersVC: UIViewController, IsMediaFilterVC, UIGestureRecogni
         img.draw(in: CGRect(x: 0, y: 0, width: thumbnailSize.width, height: thumbnailSize.height))
         let smallImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
-        return CIImage(cgImage: smallImage!.cgImage!)
+        return smallImage!.toCIImage()!
     }
 }
 
@@ -174,7 +174,7 @@ extension YPPhotoFiltersVC {
         if let applier = filter.applier,
             let thumbnailImage = thumbnailImageForFiltering,
             let outputImage = applier(thumbnailImage) {
-            return UIImage(ciImage: outputImage)
+            return outputImage.toUIImage()
         } else {
             return inputPhoto.originalImage
         }

--- a/Source/Filters/YPPhotoFiltersVC.swift
+++ b/Source/Filters/YPPhotoFiltersVC.swift
@@ -53,7 +53,13 @@ open class YPPhotoFiltersVC: UIViewController, IsMediaFilterVC, UIGestureRecogni
         thumbnailImageForFiltering = thumbFromImage(inputPhoto.image)
         DispatchQueue.global().async {
             self.filteredThumbnailImagesArray = self.filters.map { filter -> UIImage in
-                return self.getFilteredThumbnailImage(filter)
+                if let applier = filter.applier,
+                    let thumbnailImage = self.thumbnailImageForFiltering,
+                    let outputImage = applier(thumbnailImage) {
+                    return outputImage.toUIImage()
+                } else {
+                    return self.inputPhoto.originalImage
+                }
             }
             DispatchQueue.main.async {
                 self.v.collectionView.reloadData()
@@ -180,20 +186,7 @@ extension YPPhotoFiltersVC: UICollectionViewDataSource {
 extension YPPhotoFiltersVC: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectedFilter = filters[indexPath.row]
-        currentlySelectedImageThumbnail = getFilteredThumbnailImage(selectedFilter!)
+        currentlySelectedImageThumbnail = filteredThumbnailImagesArray[indexPath.row]
         self.v.imageView.image = currentlySelectedImageThumbnail
-    }
-}
-
-// MARK: - Filter applying
-extension YPPhotoFiltersVC {
-    func getFilteredThumbnailImage(_ filter: YPFilter) -> UIImage {
-        if let applier = filter.applier,
-            let thumbnailImage = thumbnailImageForFiltering,
-            let outputImage = applier(thumbnailImage) {
-            return outputImage.toUIImage()
-        } else {
-            return inputPhoto.originalImage
-        }
     }
 }

--- a/Source/Helpers/Extensions/CIImage+Extensions.swift
+++ b/Source/Helpers/Extensions/CIImage+Extensions.swift
@@ -10,7 +10,13 @@ import UIKit
 
 internal extension CIImage {
     func toUIImage() -> UIImage {
-        return UIImage(ciImage: self)
+        /* If need to reduce the process time, than use next code. But ot produce a bug with wrong filling in the simulator.
+         return UIImage(ciImage: self)
+         */
+        let context: CIContext = CIContext.init(options: nil)
+        let cgImage: CGImage = context.createCGImage(self, from: self.extent)!
+        let image: UIImage = UIImage(cgImage: cgImage)
+        return image
     }
     
     func toCGImage() -> CGImage? {

--- a/Source/Helpers/Extensions/UIImage+Extensions.swift
+++ b/Source/Helpers/Extensions/UIImage+Extensions.swift
@@ -10,6 +10,13 @@ import UIKit
 
 internal extension UIImage {
     
+    func resized(to size: CGSize) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        defer { UIGraphicsEndImageContext() }
+        draw(in: CGRect(origin: .zero, size: size))
+        return UIGraphicsGetImageFromCurrentImageContext()
+    }
+    
     /// Kudos to Trevor Harmon and his UIImage+Resize category from
     // which this code is heavily inspired.
     func resetOrientation() -> UIImage {

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -86,16 +86,14 @@ class LibraryMediaManager {
                                             return
                                             
                 }
-                guard let audioTrack = asset.tracks(withMediaType: AVMediaType.audio).first,
+                if let audioTrack = asset.tracks(withMediaType: AVMediaType.audio).first,
                     let audioCompositionTrack = assetComposition
                         .addMutableTrack(withMediaType: AVMediaType.audio,
-                                         preferredTrackID: kCMPersistentTrackID_Invalid) else {
-                                            print("⚠️ PHCachingImageManager >>> Problems with audio track")
-                                            return
+                                         preferredTrackID: kCMPersistentTrackID_Invalid) {
+                    try audioCompositionTrack.insertTimeRange(trackTimeRange, of: audioTrack, at: kCMTimeZero)
                 }
                 
                 try videoCompositionTrack.insertTimeRange(trackTimeRange, of: videoTrack, at: kCMTimeZero)
-                try audioCompositionTrack.insertTimeRange(trackTimeRange, of: audioTrack, at: kCMTimeZero)
                 
                 // 2. Create the instructions
                 

--- a/Source/Pages/Gallery/YPAssetViewContainer.swift
+++ b/Source/Pages/Gallery/YPAssetViewContainer.swift
@@ -63,7 +63,7 @@ class YPAssetViewContainer: UIView {
         
         spinner.startAnimating()
         spinnerView.backgroundColor = UIColor.black.withAlphaComponent(0.3)
-        curtain.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+        curtain.backgroundColor = UIColor.black.withAlphaComponent(0.7)
         curtain.alpha = 0
         
         if !onlySquare {

--- a/Source/Pages/Gallery/YPLibraryVC+PanGesture.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+PanGesture.swift
@@ -19,6 +19,17 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
     private let dragDiff: CGFloat = 0
     private var _isImageShown = true
     
+    // The height constraint of the view with main selected image
+    var topHeight: CGFloat {
+        get { return v.assetViewContainerConstraintTop.constant }
+        set {
+            if newValue >= v.assetZoomableViewMinimalVisibleHeight - v.assetViewContainer.frame.height {
+                v.assetViewContainerConstraintTop.constant = newValue
+            }
+        }
+    }
+    
+    // Is the main image shown
     var isImageShown: Bool {
         get { return self._isImageShown }
         set {
@@ -36,19 +47,27 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
         let panGesture = UIPanGestureRecognizer(target: self, action: #selector(panned(_:)))
         panGesture.delegate = self
         view.addGestureRecognizer(panGesture)
-        v.assetViewContainerConstraintTop.constant = 0
+        topHeight = 0
     }
     
-    func resetToOriginalState() {
-        v.assetViewContainerConstraintTop.constant = assetViewContainerOriginalConstraintTop
-        UIView.animate(withDuration: 0.3,
-                       delay: 0.0,
-                       options: .curveEaseOut,
-                       animations: v.layoutIfNeeded,
-                       completion: nil)
+    public func resetToOriginalState() {
+        topHeight = assetViewContainerOriginalConstraintTop
+        animateView()
         dragDirection = .up
     }
-
+    
+    fileprivate func animateView() {
+        UIView.animate(withDuration: 0.2,
+                       delay: 0.0,
+                       options: [.curveEaseInOut, .beginFromCurrentState],
+                       animations: {
+                        self.v.refreshImageCurtainAlpha()
+                        self.v.layoutIfNeeded()
+        }
+            ,
+                       completion: nil)
+    }
+    
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith
         otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return true
@@ -69,13 +88,17 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
     func panned(_ sender: UIPanGestureRecognizer) {
         
         let containerHeight = v.assetViewContainer.frame.height
-        if sender.state == UIGestureRecognizerState.began {
+        let currentPos = sender.location(in: v)
+        let overYLimitToStartMovingUp = currentPos.y * 1.4 < cropBottomY - dragDiff
+        
+        switch sender.state {
+        case .began:
             let view    = sender.view
             let loc     = sender.location(in: view)
             let subview = view?.hitTest(loc, with: nil)
             
             if subview == v.assetZoomableView
-                && v.assetViewContainerConstraintTop.constant == assetViewContainerOriginalConstraintTop {
+                && topHeight == assetViewContainerOriginalConstraintTop {
                 return
             }
             
@@ -84,7 +107,7 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
             
             // Move
             if dragDirection == .stop {
-                dragDirection = (v.assetViewContainerConstraintTop.constant == assetViewContainerOriginalConstraintTop)
+                dragDirection = (topHeight == assetViewContainerOriginalConstraintTop)
                     ? .up
                     : .down
             }
@@ -94,39 +117,41 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
                 (dragDirection == .down && dragStartPos.y > cropBottomY) {
                 dragDirection = .stop
             }
-        } else if sender.state == UIGestureRecognizerState.changed {
-            let currentPos = sender.location(in: v)
-            if dragDirection == .up && currentPos.y < cropBottomY - dragDiff {
-                v.assetViewContainerConstraintTop.constant =
-                    max(v.assetZoomableViewMinimalVisibleHeight - containerHeight,
-                        currentPos.y + dragDiff - containerHeight)
-            } else if dragDirection == .down && currentPos.y > cropBottomY {
-                v.assetViewContainerConstraintTop.constant =
-                    min(assetViewContainerOriginalConstraintTop, currentPos.y - containerHeight)
-            } else if dragDirection == .stop && v.collectionView.contentOffset.y < 0 {
-                dragDirection = .scroll
-                imaginaryCollectionViewOffsetStartPosY = currentPos.y
-            } else if dragDirection == .scroll {
-                v.assetViewContainerConstraintTop.constant =
+        case .changed:
+            switch dragDirection {
+            case .up:
+                if currentPos.y < cropBottomY - dragDiff {
+                    topHeight =
+                        max(v.assetZoomableViewMinimalVisibleHeight - containerHeight,
+                            currentPos.y + dragDiff - containerHeight)
+                }
+            case .down:
+                if currentPos.y > cropBottomY {
+                    topHeight =
+                        min(assetViewContainerOriginalConstraintTop, currentPos.y - containerHeight)
+                }
+            case .scroll:
+                topHeight =
                     v.assetZoomableViewMinimalVisibleHeight - containerHeight
                     + currentPos.y - imaginaryCollectionViewOffsetStartPosY
+            case .stop:
+                if v.collectionView.contentOffset.y < 0 {
+                    dragDirection = .scroll
+                    imaginaryCollectionViewOffsetStartPosY = currentPos.y
+                }
             }
-        } else {
+            
+        default:
             imaginaryCollectionViewOffsetStartPosY = 0.0
             if sender.state == UIGestureRecognizerState.ended && dragDirection == .stop {
                 return
             }
-            let currentPos = sender.location(in: v)
-            if currentPos.y < cropBottomY - dragDiff
-                && v.assetViewContainerConstraintTop.constant != assetViewContainerOriginalConstraintTop {
+            
+            if overYLimitToStartMovingUp && isImageShown == false {
                 // The largest movement
-                v.assetViewContainerConstraintTop.constant =
+                topHeight =
                     v.assetZoomableViewMinimalVisibleHeight - containerHeight
-                UIView.animate(withDuration: 0.3,
-                               delay: 0.0,
-                               options: .curveEaseOut,
-                               animations: v.layoutIfNeeded,
-                               completion: nil)
+                animateView()
                 dragDirection = .down
             } else {
                 // Get back to the original position
@@ -135,8 +160,7 @@ public class PanGestureHelper: NSObject, UIGestureRecognizerDelegate {
         }
         
         // Update isImageShown
-        isImageShown = v.assetViewContainerConstraintTop.constant == 0
-        
-        v.refreshImageCurtainAlpha()
+        isImageShown = topHeight == assetViewContainerOriginalConstraintTop
     }
 }
+

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -478,13 +478,3 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         PHPhotoLibrary.shared().unregisterChangeObserver(self)
     }
 }
-
-extension UIImage {
-    
-    func resized(to size: CGSize) -> UIImage? {
-        UIGraphicsBeginImageContextWithOptions(size, false, scale)
-        defer { UIGraphicsEndImageContext() }
-        draw(in: CGRect(origin: .zero, size: size))
-        return UIGraphicsGetImageFromCurrentImageContext()
-    }
-}

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -269,26 +269,25 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         latestImageTapped = asset.localIdentifier
         delegate?.libraryViewStartedLoading()
         
+        let completion = {
+            self.v.hideLoader()
+            self.v.hideGrid()
+            self.delegate?.libraryViewFinishedLoading()
+            self.v.assetViewContainer.refreshSquareCropButton()
+        }
+        
         DispatchQueue.global(qos: .userInitiated).async {
             switch asset.mediaType {
             case .image:
                 self.v.assetZoomableView.setImage(asset,
                                                   mediaManager: self.mediaManager,
-                                                  storedCropPosition: self.fetchStoredCrop()) {
-                    self.v.hideLoader()
-                    self.v.hideGrid()
-                    self.delegate?.libraryViewFinishedLoading()
-                    self.v.assetViewContainer.refreshSquareCropButton()
-                }
+                                                  storedCropPosition: self.fetchStoredCrop(),
+                                                  completion: completion)
             case .video:
                 self.v.assetZoomableView.setVideo(asset,
                                                   mediaManager: self.mediaManager,
-                                                  storedCropPosition: self.fetchStoredCrop()) {
-                    self.v.hideLoader()
-                    self.v.hideGrid()
-                    self.delegate?.libraryViewFinishedLoading()
-                    self.v.assetViewContainer.refreshSquareCropButton()
-                }
+                                                  storedCropPosition: self.fetchStoredCrop(),
+                                                  completion: completion)
             case .audio, .unknown:
                 ()
             }

--- a/Source/Pages/Video/YPVideoCaptureHelper.swift
+++ b/Source/Pages/Video/YPVideoCaptureHelper.swift
@@ -11,7 +11,7 @@ import AVFoundation
 import CoreMotion
 
 /// Abstracts Low Level AVFoudation details.
-class YPVideoHelper: NSObject {
+class YPVideoCaptureHelper: NSObject {
     
     public var isRecording: Bool { return videoOutput.isRecording }
     public var didCaptureVideo: ((URL) -> Void)?
@@ -256,7 +256,7 @@ class YPVideoHelper: NSObject {
     }
 }
 
-extension YPVideoHelper: AVCaptureFileOutputRecordingDelegate {
+extension YPVideoCaptureHelper: AVCaptureFileOutputRecordingDelegate {
     
     public func fileOutput(_ captureOutput: AVCaptureFileOutput,
                            didStartRecordingTo fileURL: URL,

--- a/Source/Pages/Video/YPVideoCaptureHelper.swift
+++ b/Source/Pages/Video/YPVideoCaptureHelper.swift
@@ -141,7 +141,7 @@ class YPVideoCaptureHelper: NSObject {
     // MARK: - Recording
     
     public func startRecording() {
-        let outputPath = "\(NSTemporaryDirectory())output.mov"
+        let outputPath = "\(NSTemporaryDirectory())output.\(YPConfig.video.fileType.fileExtension)"
         let outputURL = URL(fileURLWithPath: outputPath)
         let fileManager = FileManager.default
         if fileManager.fileExists(atPath: outputPath) {

--- a/Source/Pages/Video/YPVideoCaptureVC.swift
+++ b/Source/Pages/Video/YPVideoCaptureVC.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-public class YPVideoVC: UIViewController, YPPermissionCheckable {
+public class YPVideoCaptureVC: UIViewController, YPPermissionCheckable {
     
     public var didCaptureVideo: ((URL) -> Void)?
     
-    private let videoHelper = YPVideoHelper()
+    private let videoHelper = YPVideoCaptureHelper()
     private let v = YPCameraView(overlayView: nil)
     private var viewState = ViewState()
     
@@ -217,7 +217,7 @@ public class YPVideoVC: UIViewController, YPPermissionCheckable {
         }
     }
     
-    private func flashModeFrom(videoHelper: YPVideoHelper) -> FlashMode {
+    private func flashModeFrom(videoHelper: YPVideoCaptureHelper) -> FlashMode {
         if videoHelper.hasTorch() {
             switch videoHelper.currentTorchMode() {
             case .off: return .off

--- a/Source/Pages/Video/YPVideoCaptureVC.swift
+++ b/Source/Pages/Video/YPVideoCaptureVC.swift
@@ -51,6 +51,7 @@ public class YPVideoCaptureVC: UIViewController, YPPermissionCheckable {
     }
 
     func start() {
+        v.shotButton.isEnabled = false
         doAfterPermissionCheck { [weak self] in
             guard let strongSelf = self else {
                 return
@@ -59,6 +60,7 @@ public class YPVideoCaptureVC: UIViewController, YPPermissionCheckable {
                                     withVideoRecordingLimit: YPConfig.video.recordingTimeLimit,
                                     completion: {
                                         DispatchQueue.main.async {
+                                            self?.v.shotButton.isEnabled = true
                                             self?.refreshState()
                                         }
             })

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -31,7 +31,7 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     
     private var libraryVC: YPLibraryVC?
     private var cameraVC: YPCameraVC?
-    private var videoVC: YPVideoVC?
+    private var videoVC: YPVideoCaptureVC?
     
     var mode = Mode.camera
     
@@ -66,7 +66,7 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         
         // Video
         if YPConfig.screens.contains(.video) {
-            videoVC = YPVideoVC()
+            videoVC = YPVideoCaptureVC()
             videoVC?.didCaptureVideo = { [weak self] videoURL in
                 self?.didSelectItems?([YPMediaItem
                     .video(v: YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
@@ -140,7 +140,7 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
             return .library
         case is YPCameraVC:
             return .camera
-        case is YPVideoVC:
+        case is YPVideoCaptureVC:
             return .video
         default:
             return .camera
@@ -162,7 +162,7 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
             vc.checkPermission()
         } else if let cameraVC = vc as? YPCameraVC {
             cameraVC.start()
-        } else if let videoVC = vc as? YPVideoVC {
+        } else if let videoVC = vc as? YPVideoCaptureVC {
             videoVC.start()
         }
     

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -278,6 +278,10 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     
     @objc
     func close() {
+        // Cancelling exporting of all videos
+        if let libraryVC = libraryVC {
+            libraryVC.mediaManager.forseCancelExporting()
+        }
         self.didClose?()
     }
     

--- a/YPImagePicker.xcodeproj/project.pbxproj
+++ b/YPImagePicker.xcodeproj/project.pbxproj
@@ -53,7 +53,7 @@
 		99C6D6CC1F1FB5C100711DB2 /* YPImagePickerHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 99C6D6B21F1FB5C100711DB2 /* YPImagePickerHeader.h */; };
 		99C6D6CE1F1FB5C100711DB2 /* YPPhotoSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C6D6B41F1FB5C100711DB2 /* YPPhotoSaver.swift */; };
 		99C6D6CF1F1FB5C100711DB2 /* YPPickerVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C6D6B51F1FB5C100711DB2 /* YPPickerVC.swift */; };
-		99C6D6D01F1FB5C100711DB2 /* YPVideoVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C6D6B71F1FB5C100711DB2 /* YPVideoVC.swift */; };
+		99C6D6D01F1FB5C100711DB2 /* YPVideoCaptureVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C6D6B71F1FB5C100711DB2 /* YPVideoCaptureVC.swift */; };
 		99C6D6D11F1FB5C100711DB2 /* YPImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C6D6B81F1FB5C100711DB2 /* YPImagePicker.swift */; };
 		99CD962720D179FD009F5084 /* YPSelectionsGalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CD962620D179FD009F5084 /* YPSelectionsGalleryView.swift */; };
 		99CF6D1B201B6A5C00487F77 /* UICollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CF6D1A201B6A5C00487F77 /* UICollectionView+Extensions.swift */; };
@@ -64,7 +64,7 @@
 		99CF6D25201B727900487F77 /* YPLibraryVC+PanGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CF6D24201B727900487F77 /* YPLibraryVC+PanGesture.swift */; };
 		99CF6D27201B739600487F77 /* YPAlerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CF6D26201B739600487F77 /* YPAlerts.swift */; };
 		99CF6D29201B900400487F77 /* LibraryMediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CF6D28201B900400487F77 /* LibraryMediaManager.swift */; };
-		99CF6D2B201CB96700487F77 /* YPVideoHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CF6D2A201CB96700487F77 /* YPVideoHelper.swift */; };
+		99CF6D2B201CB96700487F77 /* YPVideoCaptureHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CF6D2A201CB96700487F77 /* YPVideoCaptureHelper.swift */; };
 		99D1DC2B1F9788930047F0E0 /* YPImagePickerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D1DC2A1F9788930047F0E0 /* YPImagePickerConfiguration.swift */; };
 		EB19A8F420AC41AE007F88D8 /* AVAssetTrack+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB19A8F320AC41AE007F88D8 /* AVAssetTrack+Extensions.swift */; };
 		EB1AB2EA20AC1DED00BFA79F /* CGFloat+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1AB2E920AC1DED00BFA79F /* CGFloat+Extensions.swift */; };
@@ -151,7 +151,7 @@
 		99C6D6B31F1FB5C100711DB2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		99C6D6B41F1FB5C100711DB2 /* YPPhotoSaver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPPhotoSaver.swift; sourceTree = "<group>"; };
 		99C6D6B51F1FB5C100711DB2 /* YPPickerVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPPickerVC.swift; sourceTree = "<group>"; };
-		99C6D6B71F1FB5C100711DB2 /* YPVideoVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPVideoVC.swift; sourceTree = "<group>"; };
+		99C6D6B71F1FB5C100711DB2 /* YPVideoCaptureVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPVideoCaptureVC.swift; sourceTree = "<group>"; };
 		99C6D6B81F1FB5C100711DB2 /* YPImagePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YPImagePicker.swift; sourceTree = "<group>"; };
 		99CD962620D179FD009F5084 /* YPSelectionsGalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPSelectionsGalleryView.swift; sourceTree = "<group>"; };
 		99CF6D1A201B6A5C00487F77 /* UICollectionView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Extensions.swift"; sourceTree = "<group>"; };
@@ -162,7 +162,7 @@
 		99CF6D24201B727900487F77 /* YPLibraryVC+PanGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "YPLibraryVC+PanGesture.swift"; sourceTree = "<group>"; };
 		99CF6D26201B739600487F77 /* YPAlerts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPAlerts.swift; sourceTree = "<group>"; };
 		99CF6D28201B900400487F77 /* LibraryMediaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryMediaManager.swift; sourceTree = "<group>"; };
-		99CF6D2A201CB96700487F77 /* YPVideoHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPVideoHelper.swift; sourceTree = "<group>"; };
+		99CF6D2A201CB96700487F77 /* YPVideoCaptureHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPVideoCaptureHelper.swift; sourceTree = "<group>"; };
 		99D1DC2A1F9788930047F0E0 /* YPImagePickerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YPImagePickerConfiguration.swift; sourceTree = "<group>"; };
 		A7FD716620755C2D0044A8E8 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E5287F5820B908720052153D /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -357,8 +357,8 @@
 		99C6D6B61F1FB5C100711DB2 /* Video */ = {
 			isa = PBXGroup;
 			children = (
-				99C6D6B71F1FB5C100711DB2 /* YPVideoVC.swift */,
-				99CF6D2A201CB96700487F77 /* YPVideoHelper.swift */,
+				99C6D6B71F1FB5C100711DB2 /* YPVideoCaptureVC.swift */,
+				99CF6D2A201CB96700487F77 /* YPVideoCaptureHelper.swift */,
 			);
 			path = Video;
 			sourceTree = "<group>";
@@ -614,7 +614,7 @@
 				EB473E21208E1BF400D16105 /* YPTrimError.swift in Sources */,
 				EB584C03207B990200265B38 /* AVFoundation+Extensions.swift in Sources */,
 				99C6D6BF1F1FB5C100711DB2 /* YPGridView.swift in Sources */,
-				99C6D6D01F1FB5C100711DB2 /* YPVideoVC.swift in Sources */,
+				99C6D6D01F1FB5C100711DB2 /* YPVideoCaptureVC.swift in Sources */,
 				99A052A31F20B4CA005600B3 /* YPAlbumsManager.swift in Sources */,
 				EB19A8F420AC41AE007F88D8 /* AVAssetTrack+Extensions.swift in Sources */,
 				EB473E25208E1DCA00D16105 /* AVCaptureSession+Extensions.swift in Sources */,
@@ -637,7 +637,7 @@
 				99C6D6BE1F1FB5C100711DB2 /* YPLibraryViewCell.swift in Sources */,
 				99C6D6C41F1FB5C100711DB2 /* YPFilter.swift in Sources */,
 				99C6D6C91F1FB5C100711DB2 /* YPBottomPager.swift in Sources */,
-				99CF6D2B201CB96700487F77 /* YPVideoHelper.swift in Sources */,
+				99CF6D2B201CB96700487F77 /* YPVideoCaptureHelper.swift in Sources */,
 				99019E4E2018CD31007325C2 /* YPPagerMenu.swift in Sources */,
 				99C6D6C01F1FB5C100711DB2 /* YPAssetZoomableView.swift in Sources */,
 				EB867BCF209134F100332A54 /* UIColor+Extensions.swift in Sources */,

--- a/YPImagePickerExample/YPImagePickerExample/ExampleViewController.swift
+++ b/YPImagePickerExample/YPImagePickerExample/ExampleViewController.swift
@@ -88,10 +88,10 @@ class ExampleViewController: UIViewController {
         // config.showsFilters = false
 
         /* Manage filters by yourself */
-//        config.filters = [YPFilterDescriptor(name: "Normal", filterName: ""),
-//                          YPFilterDescriptor(name: "Mono", filterName: "CIPhotoEffectMono")]
+//        config.filters = [YPFilter(name: "Mono", coreImageFilterName: "CIPhotoEffectMono"),
+//                          YPFilter(name: "Normal", coreImageFilterName: "")]
 //        config.filters.remove(at: 1)
-//        config.filters.insert(YPFilterDescriptor(name: "Blur", filterName: "CIBoxBlur"), at: 1)
+//        config.filters.insert(YPFilter(name: "Blur", coreImageFilterName: "CIBoxBlur"), at: 1)
 
         /* Enables you to opt out from saving new (or old but filtered) images to the
            user's photo library. Defaults to true. */
@@ -111,7 +111,9 @@ class ExampleViewController: UIViewController {
         /* Defines which screens are shown at launch, and their order.
            Default value is `[.library, .photo]` */
         config.screens = [.library, .photo, .video]
-
+        
+        /* Can forbid the items with very big height with this property */
+//        config.library.minWidthForItem = UIScreen.main.bounds.width * 0.8
 
         /* Defines the time limit for recording videos.
            Default is 30 seconds. */


### PR DESCRIPTION
Fixed the filters bug in simulator when not resized the thumbnail properly.
Added a loader to the filters to prevent multiple touches.
Bottom pager title now autoresized.
Curtain - increased alpha Bottom bar - height reduced to 44px like instagramm Smoother expanding of the bottom gallery.
MediaManager - Added a forse cancelling of video exporting if picker is cancelled. Fixed glitching when processing the multiple videos.
Added the minimum width property to restrict the big height images like in insta!
Fixed Filters example.
Cover in video now showing properly.
Now can add videos without audio.
Renamed VideoVC to VideoCaptureVC. Same with Helper.