### PR TITLE
Added fetchOptions as param

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -9,6 +9,7 @@
 import Foundation
 import AVFoundation
 import UIKit
+import Photos
 
 /// Typealias for code prettiness
 internal var YPConfig: YPImagePickerConfiguration { return YPImagePickerConfiguration.shared }
@@ -133,6 +134,8 @@ public struct YPImagePickerConfiguration {
 
 /// Encapsulates library specific settings.
 public struct YPConfigLibrary {
+    
+     public var options: PHFetchOptions? = nil
     
     /// Set this to true if you want to force the library output to be a squared image. Defaults to false
     public var onlySquare = false

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -21,7 +21,6 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
     internal let mediaManager = LibraryMediaManager()
     internal var latestImageTapped = ""
     internal let panGestureHelper = PanGestureHelper()
-    var userOptions: PHFetchOptions?
 
     // MARK: - Init
     
@@ -248,7 +247,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
     
     func buildPHFetchOptions() -> PHFetchOptions {
         // Sorting condition
-        if let userOpt = userOptions {
+        if let userOpt = YPConfig.library.options {
             return userOpt
         }
         let options = PHFetchOptions()

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -21,6 +21,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
     internal let mediaManager = LibraryMediaManager()
     internal var latestImageTapped = ""
     internal let panGestureHelper = PanGestureHelper()
+    var userOptions: PHFetchOptions?
 
     // MARK: - Init
     
@@ -239,12 +240,17 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             v.collectionView.selectItem(at: IndexPath(row: 0, section: 0),
                                              animated: false,
                                              scrollPosition: UICollectionViewScrollPosition())
+        } else {
+            delegate?.noPhotosForOptions()
         }
         scrollToTop()
     }
     
     func buildPHFetchOptions() -> PHFetchOptions {
         // Sorting condition
+        if let userOpt = userOptions {
+            return userOpt
+        }
         let options = PHFetchOptions()
         options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
         options.predicate = YPConfig.library.mediaType.predicate()

--- a/Source/Pages/Gallery/YPLibraryViewDelegate.swift
+++ b/Source/Pages/Gallery/YPLibraryViewDelegate.swift
@@ -13,4 +13,5 @@ public protocol YPLibraryViewDelegate: class {
     func libraryViewStartedLoading()
     func libraryViewFinishedLoading()
     func libraryViewDidToggleMultipleSelection(enabled: Bool)
+    func noPhotosForOptions()
 }

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -8,6 +8,11 @@
 
 import UIKit
 import AVFoundation
+import Photos
+
+public protocol YPImagePickerDelegate {
+    func noPhotos()
+}
 
 public class YPImagePicker: UINavigationController {
     
@@ -21,6 +26,11 @@ public class YPImagePicker: UINavigationController {
     private var _didFinishPicking: (([YPMediaItem], Bool) -> Void)?
     public func didFinishPicking(completion: @escaping (_ items: [YPMediaItem], _ cancelled: Bool) -> Void) {
         _didFinishPicking = completion
+    }
+    public var imagePickerDelegate: YPImagePickerDelegate?
+    
+    public override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .default
     }
     
     // This nifty little trick enables us to call the single version of the callbacks.
@@ -49,14 +59,18 @@ public class YPImagePicker: UINavigationController {
     
     /// Get a YPImagePicker instance with the default configuration.
     public convenience init() {
-        self.init(configuration: YPImagePickerConfiguration.shared)
+        self.init(configuration: YPImagePickerConfiguration.shared, options: nil)
     }
     
     /// Get a YPImagePicker with the specified configuration.
-    public required init(configuration: YPImagePickerConfiguration) {
+    public required init(configuration: YPImagePickerConfiguration, options: PHFetchOptions?) {
         YPImagePickerConfiguration.shared = configuration
         picker = YPPickerVC()
+        if let opt = options {
+            picker.options = opt
+        }
         super.init(nibName: nil, bundle: nil)
+        picker.imagePickerDelegate = self
     }
     
     public required init?(coder aDecoder: NSCoder) {
@@ -169,5 +183,11 @@ public class YPImagePicker: UINavigationController {
         )
         loadingView.fillContainer()
         loadingView.alpha = 0
+    }
+}
+
+extension YPImagePicker: ImagePickerDelegate {
+    func noPhotos() {
+        self.imagePickerDelegate?.noPhotos()
     }
 }

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -63,12 +63,9 @@ public class YPImagePicker: UINavigationController {
     }
     
     /// Get a YPImagePicker with the specified configuration.
-    public required init(configuration: YPImagePickerConfiguration, options: PHFetchOptions? = nil) {
+    public required init(configuration: YPImagePickerConfiguration) {
         YPImagePickerConfiguration.shared = configuration
         picker = YPPickerVC()
-        if let opt = options {
-            picker.options = opt
-        }
         super.init(nibName: nil, bundle: nil)
         picker.imagePickerDelegate = self
     }

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -59,11 +59,11 @@ public class YPImagePicker: UINavigationController {
     
     /// Get a YPImagePicker instance with the default configuration.
     public convenience init() {
-        self.init(configuration: YPImagePickerConfiguration.shared, options: nil)
+        self.init(configuration: YPImagePickerConfiguration.shared)
     }
     
     /// Get a YPImagePicker with the specified configuration.
-    public required init(configuration: YPImagePickerConfiguration, options: PHFetchOptions?) {
+    public required init(configuration: YPImagePickerConfiguration, options: PHFetchOptions? = nil) {
         YPImagePickerConfiguration.shared = configuration
         picker = YPPickerVC()
         if let opt = options {

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -19,7 +19,6 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     let albumsManager = YPAlbumsManager()
     var shouldHideStatusBar = false
     var initialStatusBarHidden = false
-    var options: PHFetchOptions?
     var imagePickerDelegate: ImagePickerDelegate?
     
     override public var prefersStatusBarHidden: Bool {
@@ -59,9 +58,6 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         // Library
         if YPConfig.screens.contains(.library) {
             libraryVC = YPLibraryVC()
-            if let opt = options, let lib = libraryVC {
-                lib.userOptions = opt
-            }
             libraryVC?.delegate = self
         }
         
@@ -230,7 +226,7 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
             label.textColor = navBarTitleColor
         }
         
-        if let _ = options {
+        if YPConfig.library.options != nil {
             titleView.sv(
                 label
             )

--- a/YPImagePickerExample/YPImagePickerExample/ExampleViewController.swift
+++ b/YPImagePickerExample/YPImagePickerExample/ExampleViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import YPImagePicker
 import AVFoundation
 import AVKit
+import Photos
 
 class ExampleViewController: UIViewController {
     var selectedItems = [YPMediaItem]()
@@ -63,7 +64,7 @@ class ExampleViewController: UIViewController {
     // MARK: - Configuration
     @objc
     func showPicker() {
-
+        
         var config = YPImagePickerConfiguration()
 
         /* Uncomment and play around with the configuration 👨‍🔬 🚀 */
@@ -148,6 +149,21 @@ class ExampleViewController: UIViewController {
         /* Here we use a per picker configuration. Configuration is always shared.
            That means than when you create one picker with configuration, than you can create other picker with just
            let picker = YPImagePicker() and the configuration will be the same as the first picker. */
+        
+        
+        /* Only show library pictures from the last 3 days */
+        //let threDaysTimeInterval: TimeInterval = 3 * 60 * 60 * 24
+        //let fromDate = Date().addingTimeInterval(-threDaysTimeInterval)
+        //let toDate = Date()
+        //let options = PHFetchOptions()
+        //options.predicate = NSPredicate(format: "creationDate > %@ && creationDate < %@", fromDate as CVarArg, toDate as CVarArg)
+        //
+        ////Just a way to set order
+        //let sortDescriptor = NSSortDescriptor(key: "creationDate", ascending: true)
+        //options.sortDescriptors = [sortDescriptor]
+        //
+        //config.library.options = options
+
         let picker = YPImagePicker(configuration: config)
 
         /* Change configuration directly */


### PR DESCRIPTION
With this code, developers can init the library with a PHFetchOptions configuration.
By doing that they will have the power to restrict the images shown by date for example.

```
let fromDate = Calendar.current.date(byAdding: dateComponent, to: Date())!
let toDate = Calendar.current.date(byAdding: dateComponent, to: Date().addingTimeInterval(5.0 * 60.0))!
let options = PHFetchOptions()
options.predicate = NSPredicate(format: "creationDate > %@ && creationDate < %@", fromDate as CVarArg, toDate as CVarArg)
        
 //Just a way to set order
let sortDescriptor = NSSortDescriptor(key: "creationDate", ascending: true)
options.sortDescriptors = [sortDescriptor]
        
var config = YPImagePickerConfiguration()
config.screens = [.library]
config.library.mediaType = .photo
config.library.onlySquare  = false
config.library.minNumberOfItems = 1
config.library.maxNumberOfItems = 10
config.albumName = "Nightlog"
        
let picker = YPImagePicker(configuration: config, options: options)
picker.imagePickerDelegate = self
```