### PR TITLE
PHAsset

### DIFF
--- a/Source/Filters/Video/YPVideoFiltersVC.swift
+++ b/Source/Filters/Video/YPVideoFiltersVC.swift
@@ -134,7 +134,7 @@ public class YPVideoFiltersVC: UIViewController, IsMediaFilterVC {
                 
                 DispatchQueue.main.async {
                     let resultVideo = YPMediaVideo(thumbnail: strongSelf.coverImageView.image!,
-                                              videoURL: destinationURL)
+                                                   videoURL: destinationURL, asset: strongSelf.inputVideo.asset)
                     didSave(YPMediaItem.video(v: resultVideo))
                     strongSelf.setupRightBarButtonItem()
                 }

--- a/Source/Models/YPMediaItem.swift
+++ b/Source/Models/YPMediaItem.swift
@@ -9,19 +9,24 @@
 import UIKit
 import Foundation
 import AVFoundation
+import Photos
+
 
 public class YPMediaPhoto {
+    
     public var image: UIImage { return modifiedImage ?? originalImage }
     public let originalImage: UIImage
     public var modifiedImage: UIImage?
     public let fromCamera: Bool
     public let exifMeta : [String : Any]?
+    public var asset: PHAsset?
     
-    init(image: UIImage, exifMeta : [String : Any]? = nil, fromCamera: Bool = false) {
+    init(image: UIImage, exifMeta : [String : Any]? = nil, fromCamera: Bool = false, asset: PHAsset? = nil) {
         self.originalImage = image
         self.modifiedImage = nil
         self.fromCamera = fromCamera
         self.exifMeta = exifMeta
+        self.asset = asset
     }
 }
 

--- a/Source/Models/YPMediaItem.swift
+++ b/Source/Models/YPMediaItem.swift
@@ -31,14 +31,17 @@ public class YPMediaPhoto {
 }
 
 public class YPMediaVideo {
+    
     public var thumbnail: UIImage
     public var url: URL
     public let fromCamera: Bool
+    public var asset: PHAsset?
 
-    init(thumbnail: UIImage, videoURL: URL, fromCamera: Bool = false) {
+    init(thumbnail: UIImage, videoURL: URL, fromCamera: Bool = false, asset: PHAsset? = nil) {
         self.thumbnail = thumbnail
         self.url = videoURL
         self.fromCamera = fromCamera
+        self.asset = asset
     }
 }
 

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -386,7 +386,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         }
     }
     
-    public func selectedMedia(photoCallback: @escaping (_ photo: UIImage, _ exifMeta : [String : Any]?) -> Void,
+    public func selectedMedia(photoCallback: @escaping (_ photo: YPMediaPhoto) -> Void,
                               videoCallback: @escaping (_ videoURL: URL) -> Void,
                               multipleItemsCallback: @escaping (_ items: [YPMediaItem]) -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
@@ -414,7 +414,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                     switch asset.asset.mediaType {
                     case .image:
                         self.fetchImageAndCrop(for: asset.asset, withCropRect: asset.cropRect) { image, exifMeta in
-                            let photo = YPMediaPhoto(image: image.resizedImageIfNeeded(), exifMeta: exifMeta)
+                            let photo = YPMediaPhoto(image: image.resizedImageIfNeeded(), exifMeta: exifMeta, asset: asset.asset)
                             resultMediaItems.append(YPMediaItem.photo(p: photo))
                             asyncGroup.leave()
                         }
@@ -449,7 +449,10 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                     self.fetchImageAndCrop(for: asset) { image, exifMeta in
                         DispatchQueue.main.async {
                             self.delegate?.libraryViewFinishedLoading()
-                            photoCallback(image.resizedImageIfNeeded(), exifMeta)
+                            let photo = YPMediaPhoto(image: image.resizedImageIfNeeded(),
+                                                     exifMeta: exifMeta,
+                                                     asset: asset)
+                            photoCallback(photo)
                         }
                     }
                 case .audio, .unknown:

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -387,7 +387,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
     }
     
     public func selectedMedia(photoCallback: @escaping (_ photo: YPMediaPhoto) -> Void,
-                              videoCallback: @escaping (_ videoURL: URL) -> Void,
+                              videoCallback: @escaping (_ videoURL: YPMediaVideo) -> Void,
                               multipleItemsCallback: @escaping (_ items: [YPMediaItem]) -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
             
@@ -422,7 +422,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                     case .video:
                         self.checkVideoLengthAndCrop(for: asset.asset, withCropRect: asset.cropRect) { videoURL in
                             let videoItem = YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
-                                                         videoURL: videoURL)
+                                                         videoURL: videoURL, asset: asset.asset)
                             resultMediaItems.append(YPMediaItem.video(v: videoItem))
                             asyncGroup.leave()
                         }
@@ -442,7 +442,9 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                     self.checkVideoLengthAndCrop(for: asset, callback: { videoURL in
                         DispatchQueue.main.async {
                             self.delegate?.libraryViewFinishedLoading()
-                            videoCallback(videoURL)
+                            let video = YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
+                                                     videoURL: videoURL, asset: asset)
+                            videoCallback(video)
                         }
                     })
                 case .image:

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -305,9 +305,8 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
         
         if mode == .library {
             libraryVC.doAfterPermissionCheck { [weak self] in
-                libraryVC.selectedMedia(photoCallback: { img, exifMeta in
-                    self?.didSelectItems?([YPMediaItem
-                        .photo(p: YPMediaPhoto(image: img, exifMeta: exifMeta))])
+                libraryVC.selectedMedia(photoCallback: { photo in
+                    self?.didSelectItems?([YPMediaItem.photo(p: photo)])
                 }, videoCallback: { videoURL in
                     self?.didSelectItems?([YPMediaItem
                         .video(v: YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -307,10 +307,9 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
             libraryVC.doAfterPermissionCheck { [weak self] in
                 libraryVC.selectedMedia(photoCallback: { photo in
                     self?.didSelectItems?([YPMediaItem.photo(p: photo)])
-                }, videoCallback: { videoURL in
+                }, videoCallback: { video in
                     self?.didSelectItems?([YPMediaItem
-                        .video(v: YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
-                                               videoURL: videoURL))])
+                        .video(v: video)])
                 }, multipleItemsCallback: { items in
                     self?.didSelectItems?(items)
                 })


### PR DESCRIPTION
Adds an `asset: PHAsset?` property for library taken photos & videos.

Things to know:
- This only there for media coming from the library
- The asset corresponds to the original one, not the filtered nor cropped.

Addresses :  https://github.com/Yummypets/YPImagePicker/issues/154 & https://github.com/Yummypets/YPImagePicker/issues/168 & https://github.com/Yummypets/YPImagePicker/issues/179


@barisozr, @Appswage, @thewozz Let me know if that looks good to you :)