### PR TITLE
Introduces `config.hidesBottomBar`

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -75,6 +75,9 @@ public struct YPImagePickerConfiguration {
     /// Defines if the status bar should be hidden when showing the picker. Default is true
     public var hidesStatusBar = true
     
+    /// Defines if the bottom bar should be hidden when showing the picker. Default is false.
+    public var hidesBottomBar = false
+
     /// Defines the preferredStatusBarAppearance
     public var preferredStatusBarStyle = UIStatusBarStyle.default
     

--- a/Source/Pages/Gallery/BottomPager/YPBottomPagerView.swift
+++ b/Source/Pages/Gallery/BottomPager/YPBottomPagerView.swift
@@ -35,8 +35,13 @@ final class YPBottomPagerView: UIView {
         } else {
             header.bottom(0)
         }
+        header.heightConstraint?.constant = YPConfig.hidesBottomBar ? 0 : 44
         
         clipsToBounds = false
+        setupScrollView()
+    }
+
+    private func setupScrollView() {
         scrollView.clipsToBounds = false
         scrollView.isPagingEnabled = true
         scrollView.showsHorizontalScrollIndicator = false

--- a/Source/Pages/Gallery/BottomPager/YPPagerMenu.swift
+++ b/Source/Pages/Gallery/BottomPager/YPPagerMenu.swift
@@ -17,6 +17,7 @@ final class YPPagerMenu: UIView {
     convenience init() {
         self.init(frame: .zero)
         backgroundColor = UIColor(r: 247, g: 247, b: 247)
+        clipsToBounds = true
     }
     
     var separators = [UIView]()

--- a/YPImagePickerExample/YPImagePickerExample/ExampleViewController.swift
+++ b/YPImagePickerExample/YPImagePickerExample/ExampleViewController.swift
@@ -139,6 +139,9 @@ class ExampleViewController: UIViewController {
         /* Defines if the status bar should be hidden when showing the picker. Default is true */
         config.hidesStatusBar = false
 
+        /* Defines if the bottom bar should be hidden when showing the picker. Default is false */
+        config.hidesBottomBar = false
+
         config.library.maxNumberOfItems = 5
         
         /* Disable scroll to change between mode */


### PR DESCRIPTION
Added an option for hiding the bottom bar, as suggested in [#231](https://github.com/Yummypets/YPImagePicker/issues/231).
```swift
/// Defines if the bottom bar should be hidden when showing the picker. Default is false
config.hidesBottomBar = true
```