### PR TITLE
Hide the bottom bar when showing a single screen

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -75,9 +75,6 @@ public struct YPImagePickerConfiguration {
     /// Defines if the status bar should be hidden when showing the picker. Default is true
     public var hidesStatusBar = true
     
-    /// Defines if the bottom bar should be hidden when showing the picker. Default is false.
-    public var hidesBottomBar = false
-
     /// Defines the preferredStatusBarAppearance
     public var preferredStatusBarStyle = UIStatusBarStyle.default
     

--- a/Source/Pages/Gallery/BottomPager/YPBottomPager.swift
+++ b/Source/Pages/Gallery/BottomPager/YPBottomPager.swift
@@ -80,6 +80,7 @@ public class YPBottomPager: UIViewController, UIScrollViewDelegate {
         let currentMenuItem = v.header.menuItems[0]
         currentMenuItem.select()
         v.header.refreshMenuItems()
+        v.hidesBottomBar = controllers.count <= 1
     }
     
     @objc

--- a/Source/Pages/Gallery/BottomPager/YPBottomPagerView.swift
+++ b/Source/Pages/Gallery/BottomPager/YPBottomPagerView.swift
@@ -35,13 +35,8 @@ final class YPBottomPagerView: UIView {
         } else {
             header.bottom(0)
         }
-        header.heightConstraint?.constant = YPConfig.hidesBottomBar ? 0 : 44
         
         clipsToBounds = false
-        setupScrollView()
-    }
-
-    private func setupScrollView() {
         scrollView.clipsToBounds = false
         scrollView.isPagingEnabled = true
         scrollView.showsHorizontalScrollIndicator = false

--- a/Source/Pages/Gallery/BottomPager/YPBottomPagerView.swift
+++ b/Source/Pages/Gallery/BottomPager/YPBottomPagerView.swift
@@ -13,7 +13,12 @@ final class YPBottomPagerView: UIView {
     
     var header = YPPagerMenu()
     var scrollView = UIScrollView()
-    
+    var hidesBottomBar = false {
+        didSet {
+            updateBottomBarVisibility()
+        }
+    }
+
     convenience init() {
         self.init(frame: .zero)
         backgroundColor = UIColor(red: 239/255, green: 238/255, blue: 237/255, alpha: 1)
@@ -35,8 +40,17 @@ final class YPBottomPagerView: UIView {
         } else {
             header.bottom(0)
         }
+        updateBottomBarVisibility()
         
         clipsToBounds = false
+        setupScrollView()
+    }
+
+    private func updateBottomBarVisibility() {
+        header.heightConstraint?.constant = hidesBottomBar ? 0 : 44
+    }
+
+    private func setupScrollView() {
         scrollView.clipsToBounds = false
         scrollView.isPagingEnabled = true
         scrollView.showsHorizontalScrollIndicator = false

--- a/Source/Pages/Gallery/BottomPager/YPPagerMenu.swift
+++ b/Source/Pages/Gallery/BottomPager/YPPagerMenu.swift
@@ -17,6 +17,7 @@ final class YPPagerMenu: UIView {
     convenience init() {
         self.init(frame: .zero)
         backgroundColor = UIColor(r: 247, g: 247, b: 247)
+        clipsToBounds = true
     }
     
     var separators = [UIView]()

--- a/Source/Pages/Gallery/BottomPager/YPPagerMenu.swift
+++ b/Source/Pages/Gallery/BottomPager/YPPagerMenu.swift
@@ -17,7 +17,6 @@ final class YPPagerMenu: UIView {
     convenience init() {
         self.init(frame: .zero)
         backgroundColor = UIColor(r: 247, g: 247, b: 247)
-        clipsToBounds = true
     }
     
     var separators = [UIView]()

--- a/YPImagePickerExample/YPImagePickerExample/ExampleViewController.swift
+++ b/YPImagePickerExample/YPImagePickerExample/ExampleViewController.swift
@@ -139,9 +139,6 @@ class ExampleViewController: UIViewController {
         /* Defines if the status bar should be hidden when showing the picker. Default is true */
         config.hidesStatusBar = false
 
-        /* Defines if the bottom bar should be hidden when showing the picker. Default is false */
-        config.hidesBottomBar = false
-
         config.library.maxNumberOfItems = 5
         
         /* Disable scroll to change between mode */


### PR DESCRIPTION
Hide the bottom bar when showing a single screen as suggested by @cwestMobile in https://github.com/Yummypets/YPImagePicker/issues/231

cc @s4cha, @NikKovIos