### PR TITLE
Allow no selection when multi-selecting

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -136,11 +136,6 @@ extension YPLibraryVC: UICollectionViewDelegate {
         let previouslySelectedIndexPath = IndexPath(row: currentlySelectedIndex, section: 0)
         currentlySelectedIndex = indexPath.row
 
-        // If this is the only selected cell, do not deselect.
-        if selection.count == 1 && selection.first?.index == indexPath.row {
-            return
-        }
-        
         changeAsset(mediaManager.fetchResult[indexPath.row])
         panGestureHelper.resetToOriginalState()
         
@@ -165,6 +160,7 @@ extension YPLibraryVC: UICollectionViewDelegate {
         } else {
             let previouslySelectedIndices = selection
             selection.removeAll()
+            addToSelection(indexPath: indexPath)
             if let selectedRow = previouslySelectedIndices.first?.index {
                 let previouslySelectedIndexPath = IndexPath(row: selectedRow, section: 0)
                 collectionView.reloadItems(at: [previouslySelectedIndexPath])

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -153,6 +153,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             }
         } else {
             selection.removeAll()
+            addToSelection(indexPath: IndexPath(row: currentlySelectedIndex, section: 0))
         }
 
         v.assetViewContainer.setMultipleSelectionMode(on: multipleSelectionEnabled)
@@ -239,6 +240,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             v.collectionView.selectItem(at: IndexPath(row: 0, section: 0),
                                              animated: false,
                                              scrollPosition: UICollectionView.ScrollPosition())
+            addToSelection(indexPath: IndexPath(row: 0, section: 0))
         } else {
             delegate?.noPhotosForOptions()
         }

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -272,7 +272,6 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
     }
     
     func changeAsset(_ asset: PHAsset) {
-        mediaManager.selectedAsset = asset
         latestImageTapped = asset.localIdentifier
         delegate?.libraryViewStartedLoading()
         
@@ -392,76 +391,54 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                               videoCallback: @escaping (_ videoURL: YPMediaVideo) -> Void,
                               multipleItemsCallback: @escaping (_ items: [YPMediaItem]) -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
-            
-            // Multiple selection
-            if self.multipleSelectionEnabled && self.selection.count > 1 {
-                let selectedAssets: [(asset: PHAsset, cropRect: CGRect?)] = self.selection.map {
-                    return (self.mediaManager.fetchResult[$0.index], $0.cropRect)
-                }
-                
-                // Check video length
-                for asset in selectedAssets {
-                    if self.fitsVideoLengthLimits(asset: asset.asset) == false {
-                        return
-                    }
-                }
-                
-                // Fill result media items array
-                var resultMediaItems: [YPMediaItem] = []
-                let asyncGroup = DispatchGroup()
-                
-                for asset in selectedAssets {
-                    asyncGroup.enter()
-                    
-                    switch asset.asset.mediaType {
-                    case .image:
-                        self.fetchImageAndCrop(for: asset.asset, withCropRect: asset.cropRect) { image, exifMeta in
-                            let photo = YPMediaPhoto(image: image.resizedImageIfNeeded(), exifMeta: exifMeta, asset: asset.asset)
-                            resultMediaItems.append(YPMediaItem.photo(p: photo))
-                            asyncGroup.leave()
-                        }
-                        
-                    case .video:
-                        self.checkVideoLengthAndCrop(for: asset.asset, withCropRect: asset.cropRect) { videoURL in
-                            let videoItem = YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
-                                                         videoURL: videoURL, asset: asset.asset)
-                            resultMediaItems.append(YPMediaItem.video(v: videoItem))
-                            asyncGroup.leave()
-                        }
-                    default:
-                        break
-                    }
-                }
-                
-                asyncGroup.notify(queue: .main) {
-                    multipleItemsCallback(resultMediaItems)
-                    self.delegate?.libraryViewFinishedLoading()
-                }
-        } else {
-                let asset = self.mediaManager.selectedAsset!
-                switch asset.mediaType {
-                case .video:
-                    self.checkVideoLengthAndCrop(for: asset, callback: { videoURL in
-                        DispatchQueue.main.async {
-                            self.delegate?.libraryViewFinishedLoading()
-                            let video = YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
-                                                     videoURL: videoURL, asset: asset)
-                            videoCallback(video)
-                        }
-                    })
-                case .image:
-                    self.fetchImageAndCrop(for: asset) { image, exifMeta in
-                        DispatchQueue.main.async {
-                            self.delegate?.libraryViewFinishedLoading()
-                            let photo = YPMediaPhoto(image: image.resizedImageIfNeeded(),
-                                                     exifMeta: exifMeta,
-                                                     asset: asset)
-                            photoCallback(photo)
-                        }
-                    }
-                case .audio, .unknown:
+            let selectedAssets: [(asset: PHAsset, cropRect: CGRect?)] = self.selection.map {
+                return (self.mediaManager.fetchResult[$0.index], $0.cropRect)
+            }
+
+            // Check video length
+            for asset in selectedAssets {
+                if self.fitsVideoLengthLimits(asset: asset.asset) == false {
                     return
                 }
+            }
+
+            // Fill result media items array
+            var resultMediaItems: [YPMediaItem] = []
+            let asyncGroup = DispatchGroup()
+
+            for asset in selectedAssets {
+                asyncGroup.enter()
+
+                switch asset.asset.mediaType {
+                case .image:
+                    self.fetchImageAndCrop(for: asset.asset, withCropRect: asset.cropRect) { image, exifMeta in
+                        let photo = YPMediaPhoto(image: image.resizedImageIfNeeded(), exifMeta: exifMeta, asset: asset.asset)
+                        resultMediaItems.append(YPMediaItem.photo(p: photo))
+                        asyncGroup.leave()
+                    }
+
+                case .video:
+                    self.checkVideoLengthAndCrop(for: asset.asset, withCropRect: asset.cropRect) { videoURL in
+                        let videoItem = YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
+                                                     videoURL: videoURL, asset: asset.asset)
+                        resultMediaItems.append(YPMediaItem.video(v: videoItem))
+                        asyncGroup.leave()
+                    }
+                default:
+                    break
+                }
+            }
+
+            asyncGroup.notify(queue: .main) {
+                if resultMediaItems.count == 1, let onlyOneItem = resultMediaItems.first {
+                    switch onlyOneItem {
+                    case let .photo(p): photoCallback(p)
+                    case let .video(v): videoCallback(v)
+                    }
+                } else {
+                    multipleItemsCallback(resultMediaItems)
+                }
+                self.delegate?.libraryViewFinishedLoading()
             }
         }
     }

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -281,10 +281,8 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
             navigationItem.rightBarButtonItem?.tintColor = YPConfig.colors.tintColor
             
             // Disable Next Button until minNumberOfItems is reached.
-            let minNumberOfItems = YPConfig.library.minNumberOfItems
-            if minNumberOfItems > 1 {
-                navigationItem.rightBarButtonItem?.isEnabled = libraryVC!.selection.count >= minNumberOfItems
-            }
+            navigationItem.rightBarButtonItem?.isEnabled = libraryVC!.selection.count >= YPConfig.library.minNumberOfItems
+
         case .camera:
             navigationItem.titleView = nil
             title = cameraVC?.title
@@ -359,6 +357,7 @@ extension YPPickerVC: YPLibraryViewDelegate {
         
         v.header.bottomConstraint?.constant = enabled ? offset : 0
         v.layoutIfNeeded()
+        updateUI()
     }
     
     public func noPhotosForOptions() {


### PR DESCRIPTION
Attempt to fix #247, as I can't see the point of not allowing this.

I also tried to maintain `selection` variable so it always contains what is actually selected (as I think this is more readable and understandable and reliable). Hopefully I didn't break anything else! ;)