### PR TITLE
Improve testability

### DIFF
--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.2</string>
+	<string>3.5.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Models/YPMediaItem.swift
+++ b/Source/Models/YPMediaItem.swift
@@ -21,7 +21,7 @@ public class YPMediaPhoto {
     public let exifMeta : [String : Any]?
     public var asset: PHAsset?
     
-    init(image: UIImage, exifMeta : [String : Any]? = nil, fromCamera: Bool = false, asset: PHAsset? = nil) {
+    public init(image: UIImage, exifMeta : [String : Any]? = nil, fromCamera: Bool = false, asset: PHAsset? = nil) {
         self.originalImage = image
         self.modifiedImage = nil
         self.fromCamera = fromCamera
@@ -37,7 +37,7 @@ public class YPMediaVideo {
     public let fromCamera: Bool
     public var asset: PHAsset?
 
-    init(thumbnail: UIImage, videoURL: URL, fromCamera: Bool = false, asset: PHAsset? = nil) {
+    public init(thumbnail: UIImage, videoURL: URL, fromCamera: Bool = false, asset: PHAsset? = nil) {
         self.thumbnail = thumbnail
         self.url = videoURL
         self.fromCamera = fromCamera


### PR DESCRIPTION
Hi @s4cha I would like make initializers public for YPMediaPhoto and YPMediaVideo (it improves testability, because you can create new instance of YPMediaPhoto or YPMediaVideo). I know that in that case we can use @testable import but not if you're using Carthage because framework is built in Release mode and @testable is not available.