### PR TITLE
Quick fix tap to focus #286

### DIFF
--- a/Source/Pages/Photo/YPCameraView.swift
+++ b/Source/Pages/Photo/YPCameraView.swift
@@ -26,8 +26,8 @@ class YPCameraView: UIView, UIGestureRecognizerDelegate {
         if let overlayView = overlayView {
             // View Hierarchy
             sv(
-                previewViewContainer,
                 overlayView,
+                previewViewContainer,
                 progressBar,
                 timeElapsedLabel,
                 flashButton,


### PR DESCRIPTION
Simple fix for Tap to Focus:

## The issue

The order of the view hierarchy was wrong and the gesture recogniser wasn't able to recognize anything.

## Fix

Reorder hierarchy so overlayView is always on top and is able to capture the gestures.

## Walk-around

```
pod 'YPImagePicker', git: 'https://github.com/bithavoc/YPImagePicker.git', branch: 'feature/286'
```
