### PR TITLE
Select previously selected image when deselecting in multi-selection

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -67,7 +67,15 @@ extension YPLibraryVC {
                 }
             }
             v.collectionView.reloadItems(at: selectedIndexPaths)
-
+			
+            // Replace the current selected image with the previously selected one
+            if let previouslySelectedIndexPath = selectedIndexPaths.last {
+                v.collectionView.deselectItem(at: indexPath, animated: false)
+                v.collectionView.selectItem(at: previouslySelectedIndexPath, animated: false, scrollPosition: [])
+                currentlySelectedIndex = previouslySelectedIndexPath.row
+                changeAsset(mediaManager.fetchResult[previouslySelectedIndexPath.row])
+            }
+			
             checkLimit()
         }
     }


### PR DESCRIPTION
## Current state
Currently, when deselecting an image in the multi-selection mode, the cell is not actually deselected. Instead it's just removed from the selection array. 

## Proposed change
With this PR, when deselecting an image in multi-selection mode, the current preview will be replaced by the previously selected image.