### PR TITLE
Fix french wording

### DIFF
--- a/Resources/fr.lproj/YPImagePickerLocalizable.strings
+++ b/Resources/fr.lproj/YPImagePickerLocalizable.strings
@@ -9,7 +9,7 @@
 "YPImagePickerOk" = "Ok"; //ignore-same-translation-warning
 "YPImagePickerPermissionDeniedPopupCancel" = "Annuler";
 "YPImagePickerPermissionDeniedPopupGrantPermission" = "Donner la permission";
-"YPImagePickerPermissionDeniedPopupMessage" = "Vous devez authorizer l'accès";
+"YPImagePickerPermissionDeniedPopupMessage" = "Vous devez authoriser l'accès";
 "YPImagePickerPermissionDeniedPopupTitle" = "Permission refusée";
 "YPImagePickerPhoto" = "Photo"; //ignore-same-translation-warning
 "YPImagePickerProcessing" = "Chargement..";


### PR DESCRIPTION
Update French YPImagePickerLocalizable.strings.
Line 12:
- "authorizer" to "authoriser"