### PR TITLE
Fix app crash when permission to access photo roll not granted

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -132,7 +132,12 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
 
     @objc
     func multipleSelectionButtonTapped() {
-        
+        doAfterPermissionCheck { [weak self] in
+            self?.showMultipleSelection()
+        }
+    }
+    
+    private func showMultipleSelection() {
         if !multipleSelectionEnabled {
             selection.removeAll()
         }


### PR DESCRIPTION
This will fix following issue:

Steps to reproduce
1. Open ImagePicker
2. Cancel Permission alert
3. Swipe right to get to the Library or press the button on bottom
4. Cancel Permission alert
5. Tap on the multipleSelectionButton button (button with stacked boxes)

App will crash