### PR TITLE
Problem: in multi selection mode, click the selected photo repeatedly, and the original zoom of the photo will be reset.

### DIFF
--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -60,7 +60,7 @@ final class YPAssetZoomableView: UIScrollView {
     public func setVideo(_ video: PHAsset,
                          mediaManager: LibraryMediaManager,
                          storedCropPosition: YPLibrarySelection?,
-                         completion: @escaping () -> Void) {
+                         completion: @escaping () -> Void,updateCropInfo: @escaping () -> Void) {
         mediaManager.imageManager?.fetchPreviewFor(video: video) { [weak self] preview in
             guard let strongSelf = self else { return }
             guard strongSelf.currentAsset != video else { completion() ; return }
@@ -80,6 +80,8 @@ final class YPAssetZoomableView: UIScrollView {
             // Stored crop position in multiple selection
             if let scp173 = storedCropPosition {
                 strongSelf.applyStoredCropPosition(scp173)
+                //MARK: add update CropInfo after multiple
+                updateCropInfo()
             }
         }
         mediaManager.imageManager?.fetchPlayerItem(for: video) { [weak self] playerItem in
@@ -95,7 +97,7 @@ final class YPAssetZoomableView: UIScrollView {
     public func setImage(_ photo: PHAsset,
                          mediaManager: LibraryMediaManager,
                          storedCropPosition: YPLibrarySelection?,
-                         completion: @escaping () -> Void) {
+                         completion: @escaping () -> Void,updateCropInfo: @escaping () -> Void) {
         guard currentAsset != photo else { DispatchQueue.main.async { completion() }; return }
         currentAsset = photo
         
@@ -122,6 +124,8 @@ final class YPAssetZoomableView: UIScrollView {
             // Stored crop position in multiple selection
             if let scp173 = storedCropPosition {
                 strongSelf.applyStoredCropPosition(scp173)
+                //MARK: add update CropInfo after multiple
+                updateCropInfo()
             }
         }
     }

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -322,18 +322,22 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             self.updateCropInfo()
         }
         
+        let updateCropInfo = {
+            self.updateCropInfo()
+        }
+        //MARK: add a func(updateCropInfo) after crop multiple
         DispatchQueue.global(qos: .userInitiated).async {
             switch asset.mediaType {
             case .image:
                 self.v.assetZoomableView.setImage(asset,
                                                   mediaManager: self.mediaManager,
                                                   storedCropPosition: self.fetchStoredCrop(),
-                                                  completion: completion)
+                                                  completion: completion,updateCropInfo: updateCropInfo)
             case .video:
                 self.v.assetZoomableView.setVideo(asset,
                                                   mediaManager: self.mediaManager,
                                                   storedCropPosition: self.fetchStoredCrop(),
-                                                  completion: completion)
+                                                  completion: completion,updateCropInfo: updateCropInfo)
             case .audio, .unknown:
                 ()
             @unknown default:


### PR DESCRIPTION
My English is not good, I hope you understand. 

Problem: in multi selection mode, click the selected photo repeatedly, and the original zoom of the photo will be reset.

Method: after restoring the scale of the selected photo, add the scale record to the array again.

If the original intention is to reset, would you please tell me the reason? 

Thank you very much.

问题：在多选模式下，重复点击已选中的照片，照片原有缩放会被重置

方法：在复原选中照片缩放比例后，将缩放记录再次添加到数组內

如果本意就是重置，那能否告知原因，十分感谢

