### PR TITLE
Make default mode of "square" images settable in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ config.filters = [DefaultYPFilters...]
 ```swift
 config.library.options = nil
 config.library.onlySquare = false
-config.library.defaultSquare = true
 config.library.minWidthForItem = nil
 config.library.mediaType = YPlibraryMediaType.photo
 config.library.maxNumberOfItems = 1

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ config.filters = [DefaultYPFilters...]
 ```swift
 config.library.options = nil
 config.library.onlySquare = false
+config.library.defaultSquare = true
 config.library.minWidthForItem = nil
 config.library.mediaType = YPlibraryMediaType.photo
 config.library.maxNumberOfItems = 1

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -159,11 +159,11 @@ public struct YPConfigLibrary {
     
     public var options: PHFetchOptions? = nil
 
-    /// default to square cropping. Ignored if onlySquare is true. Defaults to true
-    public var defaultSquare = true
-
-    /// Set this to true if you want to force the library output to be a squared image. Defaults to false
+    /// Set this to true if you want to force the library output to be a squared image. Defaults to false.
     public var onlySquare = false
+    
+    /// Sets the cropping style to square or not. Ignored if `onlySquare` is true. Defaults to true.
+    public var isSquareByDefault = true
     
     /// Minimum width, to prevent selectiong too high images. Have sense if onlySquare is true and the image is portrait.
     public var minWidthForItem: CGFloat?

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -158,7 +158,10 @@ public struct YPImagePickerConfiguration {
 public struct YPConfigLibrary {
     
     public var options: PHFetchOptions? = nil
-    
+
+    /// default to square cropping. Ignored if onlySquare is true. Defaults to true
+    public var defaultSquare = true
+
     /// Set this to true if you want to force the library output to be a squared image. Defaults to false
     public var onlySquare = false
     

--- a/Source/Pages/Gallery/YPAssetViewContainer.swift
+++ b/Source/Pages/Gallery/YPAssetViewContainer.swift
@@ -23,7 +23,7 @@ class YPAssetViewContainer: UIView {
     public var isShown = true
     
     private let spinner = UIActivityIndicatorView(style: .white)
-    private var shouldCropToSquare = YPConfig.library.defaultSquare
+    private var shouldCropToSquare = YPConfig.library.isSquareByDefault
     private var isMultipleSelection = false
 
     override func awakeFromNib() {

--- a/Source/Pages/Gallery/YPAssetViewContainer.swift
+++ b/Source/Pages/Gallery/YPAssetViewContainer.swift
@@ -23,7 +23,7 @@ class YPAssetViewContainer: UIView {
     public var isShown = true
     
     private let spinner = UIActivityIndicatorView(style: .white)
-    private var shouldCropToSquare = true
+    private var shouldCropToSquare = YPConfig.library.defaultSquare
     private var isMultipleSelection = false
 
     override func awakeFromNib() {


### PR DESCRIPTION
Currently, you can force all images to be square when coming from the library, or you can allow the user to select the mode. But the selector still comes up in square mode by default. This new option allows you to configure what the default should be.

Fixes #317. I realize it was closed, but the author didn't express I think what he wanted clearly enough.