### PR TITLE
Add overlay type

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -198,6 +198,9 @@ public struct YPConfigLibrary {
     
     /// Allow to preselected media items
     public var preselectedItems: [YPMediaItem]?
+    
+    /// Show or hide the grid show on top of the selected item
+    public var showGrid: Bool = true
 }
 
 /// Encapsulates video specific settings.

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -199,8 +199,8 @@ public struct YPConfigLibrary {
     /// Allow to preselected media items
     public var preselectedItems: [YPMediaItem]?
     
-    /// Show or hide the grid show on top of the selected item
-    public var showGrid: Bool = true
+    /// Set the overlay type shown on top of the selected library item
+    public var itemOverlayType: YPItemOverlayType = .grid
 }
 
 /// Encapsulates video specific settings.
@@ -236,6 +236,11 @@ public struct YPConfigVideo {
 public struct YPConfigSelectionsGallery {
     /// Defines if the remove button should be hidden when showing the gallery. Default is true.
     public var hidesRemoveButton = true
+}
+
+public enum YPItemOverlayType {
+    case none
+    case grid
 }
 
 public enum YPlibraryMediaType {

--- a/Source/Pages/Gallery/YPAssetViewContainer.swift
+++ b/Source/Pages/Gallery/YPAssetViewContainer.swift
@@ -26,12 +26,18 @@ class YPAssetViewContainer: UIView {
     private var shouldCropToSquare = YPConfig.library.isSquareByDefault
     private var isMultipleSelection = false
 
+    public var showGrid = YPConfig.library.showGrid
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         
-        addSubview(grid)
-        grid.frame = frame
-        clipsToBounds = true
+        if showGrid {
+            addSubview(grid)
+            grid.frame = frame
+            clipsToBounds = true
+            
+            grid.alpha = 0
+        }
         
         for sv in subviews {
             if let cv = sv as? YPAssetZoomableView {
@@ -39,8 +45,6 @@ class YPAssetViewContainer: UIView {
                 zoomableView?.myDelegate = self
             }
         }
-        
-        grid.alpha = 0
         
         let touchDownGR = UILongPressGestureRecognizer(target: self,
                                                        action: #selector(handleTouchDown))
@@ -125,9 +129,11 @@ extension YPAssetViewContainer: YPAssetZoomableViewDelegate {
     public func ypAssetZoomableViewDidLayoutSubviews(_ zoomableView: YPAssetZoomableView) {
         let newFrame = zoomableView.assetImageView.convert(zoomableView.assetImageView.bounds, to: self)
         
-        // update grid position
-        grid.frame = frame.intersection(newFrame)
-        grid.layoutIfNeeded()
+        if showGrid {
+            // update grid position
+            grid.frame = frame.intersection(newFrame)
+            grid.layoutIfNeeded()
+        }
         
         // Update play imageView position - bringing the playImageView from the videoView to assetViewContainer,
         // but the controll for appearing it still in videoView.
@@ -138,6 +144,9 @@ extension YPAssetViewContainer: YPAssetZoomableViewDelegate {
     }
     
     public func ypAssetZoomableViewScrollViewDidZoom() {
+        guard showGrid else {
+            return
+        }
         if isShown {
             UIView.animate(withDuration: 0.1) {
                 self.grid.alpha = 1
@@ -146,6 +155,9 @@ extension YPAssetViewContainer: YPAssetZoomableViewDelegate {
     }
     
     public func ypAssetZoomableViewScrollViewDidEndZooming() {
+        guard showGrid else {
+            return
+        }
         UIView.animate(withDuration: 0.3) {
             self.grid.alpha = 0
         }
@@ -165,6 +177,9 @@ extension YPAssetViewContainer: UIGestureRecognizerDelegate {
     
     @objc
     private func handleTouchDown(sender: UILongPressGestureRecognizer) {
+        guard showGrid else {
+            return
+        }
         switch sender.state {
         case .began:
             if isShown {

--- a/Source/Pages/Gallery/YPAssetViewContainer.swift
+++ b/Source/Pages/Gallery/YPAssetViewContainer.swift
@@ -14,7 +14,7 @@ import AVFoundation
 /// The container for asset (video or image). It containts the YPGridView and YPAssetZoomableView.
 class YPAssetViewContainer: UIView {
     public var zoomableView: YPAssetZoomableView?
-    public let grid = YPGridView()
+    public var itemOverlay: UIView?
     public let curtain = UIView()
     public let spinnerView = UIView()
     public let squareCropButton = UIButton()
@@ -26,17 +26,24 @@ class YPAssetViewContainer: UIView {
     private var shouldCropToSquare = YPConfig.library.isSquareByDefault
     private var isMultipleSelection = false
 
-    public var showGrid = YPConfig.library.showGrid
+    public var itemOverlayType = YPConfig.library.itemOverlayType
     
     override func awakeFromNib() {
         super.awakeFromNib()
         
-        if showGrid {
-            addSubview(grid)
-            grid.frame = frame
+        switch itemOverlayType {
+        case .grid:
+            itemOverlay = YPGridView()
+        default:
+            break
+        }
+        
+        if let itemOverlay = itemOverlay {
+            addSubview(itemOverlay)
+            itemOverlay.frame = frame
             clipsToBounds = true
             
-            grid.alpha = 0
+            itemOverlay.alpha = 0
         }
         
         for sv in subviews {
@@ -129,10 +136,10 @@ extension YPAssetViewContainer: YPAssetZoomableViewDelegate {
     public func ypAssetZoomableViewDidLayoutSubviews(_ zoomableView: YPAssetZoomableView) {
         let newFrame = zoomableView.assetImageView.convert(zoomableView.assetImageView.bounds, to: self)
         
-        if showGrid {
+        if let itemOverlay = itemOverlay {
             // update grid position
-            grid.frame = frame.intersection(newFrame)
-            grid.layoutIfNeeded()
+            itemOverlay.frame = frame.intersection(newFrame)
+            itemOverlay.layoutIfNeeded()
         }
         
         // Update play imageView position - bringing the playImageView from the videoView to assetViewContainer,
@@ -144,22 +151,22 @@ extension YPAssetViewContainer: YPAssetZoomableViewDelegate {
     }
     
     public func ypAssetZoomableViewScrollViewDidZoom() {
-        guard showGrid else {
+        guard let itemOverlay = itemOverlay else {
             return
         }
         if isShown {
             UIView.animate(withDuration: 0.1) {
-                self.grid.alpha = 1
+                itemOverlay.alpha = 1
             }
         }
     }
     
     public func ypAssetZoomableViewScrollViewDidEndZooming() {
-        guard showGrid else {
+        guard let itemOverlay = itemOverlay else {
             return
         }
         UIView.animate(withDuration: 0.3) {
-            self.grid.alpha = 0
+            itemOverlay.alpha = 0
         }
     }
 }
@@ -177,19 +184,19 @@ extension YPAssetViewContainer: UIGestureRecognizerDelegate {
     
     @objc
     private func handleTouchDown(sender: UILongPressGestureRecognizer) {
-        guard showGrid else {
+        guard let itemOverlay = itemOverlay else {
             return
         }
         switch sender.state {
         case .began:
             if isShown {
                 UIView.animate(withDuration: 0.1) {
-                    self.grid.alpha = 1
+                    itemOverlay.alpha = 1
                 }
             }
         case .ended:
             UIView.animate(withDuration: 0.3) {
-                self.grid.alpha = 0
+                itemOverlay.alpha = 0
             }
         default: ()
         }

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -315,7 +315,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         delegate?.libraryViewStartedLoadingImage()
         
         let completion = { (isLowResIntermediaryImage: Bool) in
-            self.v.hideGrid()
+            self.v.hideOverlayView()
             self.v.assetViewContainer.refreshSquareCropButton()
             self.updateCropInfo()
             if !isLowResIntermediaryImage {

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -97,10 +97,10 @@ extension YPLibraryView {
         return xibView
     }
     
-    // MARK: - Grid
+    // MARK: - Overlay view
     
-    func hideGrid() {
-        assetViewContainer.grid.alpha = 0
+    func hideOverlayView() {
+        assetViewContainer.itemOverlay?.alpha = 0
     }
     
     // MARK: - Loader and progress

--- a/YPImagePickerExample/YPImagePickerExample/ExampleViewController.swift
+++ b/YPImagePickerExample/YPImagePickerExample/ExampleViewController.swift
@@ -81,7 +81,7 @@ class ExampleViewController: UIViewController {
 
         /* Choose what media types are available in the library. Defaults to `.photo` */
         config.library.mediaType = .photoAndVideo
-
+      config.library.itemOverlayType = .grid
         /* Enables selecting the front camera by default, useful for avatars. Defaults to false */
         // config.usesFrontCamera = true
 


### PR DESCRIPTION
By adding an overlay type we can show or hide the grid, and potentially add more overlays. Such as a circle overlay, like when choosing a profile image in Instagram.