### PR TITLE
Correcting preferredTransform of an asset

### DIFF
--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -98,6 +98,9 @@ class LibraryMediaManager {
                 // Layer Instructions
                 let layerInstructions = AVMutableVideoCompositionLayerInstruction(assetTrack: videoCompositionTrack)
                 var transform = videoTrack.preferredTransform
+                let videoSize = videoTrack.naturalSize.applying(transform)
+                transform.tx = (videoSize.width < 0) ? abs(videoSize.width) : 0.0
+                transform.ty = (videoSize.height < 0) ? abs(videoSize.height) : 0.0
                 transform.tx -= cropRect.minX
                 transform.ty -= cropRect.minY
                 layerInstructions.setTransform(transform, at: CMTime.zero)


### PR DESCRIPTION
Some videos will not have value of tx or ty, we need to set it to 0.0 before applying the cropRect. Without this correction, we would have a black video in "exportSession?.exportAsynchronously({})"  for those video which don't have tx or ty values. This will fix issue #474