### PR TITLE
Support for displaying on iPad 

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ YPImagePickerConfiguration.shared = config
 let picker = YPImagePicker()
 ```
 
+When displaying picker on iPad, picker will support one size only you should set it before displaying it: 
+```
+let preferredContentSize = CGSize(width: 500, height: 600);
+YPImagePickerConfiguration.widthOniPad = preferredContentSize.width;
+
+// Now you can Display the picker with preferred size in dialog, popup etc
+
+```
+
 ## Usage
 
 First things first `import YPImagePicker`.  

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -17,6 +17,19 @@ internal var YPConfig: YPImagePickerConfiguration { return YPImagePickerConfigur
 public struct YPImagePickerConfiguration {
     public static var shared: YPImagePickerConfiguration = YPImagePickerConfiguration()
     
+    
+    public static var widthOniPad : CGFloat = -1
+    
+    public static var screenWidth : CGFloat {
+        get {
+            var screenWidth : CGFloat = UIScreen.main.bounds.width
+            if UIDevice.current.userInterfaceIdiom == .pad && YPImagePickerConfiguration.widthOniPad > 0 {
+                screenWidth =  YPImagePickerConfiguration.widthOniPad
+            }
+            return screenWidth
+        }
+    }
+    
     public init() {}
     
     /// Scroll to change modes, defaults to true

--- a/Source/Filters/Crop/YPCropView.swift
+++ b/Source/Filters/Crop/YPCropView.swift
@@ -57,7 +57,8 @@ class YPCropView: UIView {
         // Fit image differently depnding on its ratio.
         let imageRatio: Double = Double(image.size.width / image.size.height)
         if ratio > imageRatio {
-            let scaledDownRatio = UIScreen.main.bounds.width / image.size.width
+            let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
+            let scaledDownRatio = hack_ScreenWidth / image.size.width
             imageView.width(image.size.width * scaledDownRatio )
             imageView.centerInContainer()
         } else if ratio < imageRatio {

--- a/Source/Filters/Crop/YPCropView.swift
+++ b/Source/Filters/Crop/YPCropView.swift
@@ -57,8 +57,8 @@ class YPCropView: UIView {
         // Fit image differently depnding on its ratio.
         let imageRatio: Double = Double(image.size.width / image.size.height)
         if ratio > imageRatio {
-            let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
-            let scaledDownRatio = hack_ScreenWidth / image.size.width
+            let screenWidth = YPImagePickerConfiguration.screenWidth
+            let scaledDownRatio = screenWidth / image.size.width
             imageView.width(image.size.width * scaledDownRatio )
             imageView.centerInContainer()
         } else if ratio < imageRatio {

--- a/Source/Helpers/Extensions/PHCachingImageManager+Extensions.swift
+++ b/Source/Helpers/Extensions/PHCachingImageManager+Extensions.swift
@@ -56,8 +56,7 @@ extension PHCachingImageManager {
         let options = PHImageRequestOptions()
         options.isNetworkAccessAllowed = true
         options.isSynchronous = true
-        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
-        let screenWidth = hack_ScreenWidth;
+        let screenWidth = YPImagePickerConfiguration.screenWidth
         let ts = CGSize(width: screenWidth, height: screenWidth)
         requestImage(for: asset, targetSize: ts, contentMode: .aspectFill, options: options) { image, _ in
             if let image = image {

--- a/Source/Helpers/Extensions/PHCachingImageManager+Extensions.swift
+++ b/Source/Helpers/Extensions/PHCachingImageManager+Extensions.swift
@@ -56,7 +56,8 @@ extension PHCachingImageManager {
         let options = PHImageRequestOptions()
         options.isNetworkAccessAllowed = true
         options.isSynchronous = true
-        let screenWidth = UIScreen.main.bounds.width
+        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
+        let screenWidth = hack_ScreenWidth;
         let ts = CGSize(width: screenWidth, height: screenWidth)
         requestImage(for: asset, targetSize: ts, contentMode: .aspectFill, options: options) { image, _ in
             if let image = image {

--- a/Source/Pages/Gallery/BottomPager/YPBottomPager.swift
+++ b/Source/Pages/Gallery/BottomPager/YPBottomPager.swift
@@ -49,7 +49,8 @@ open class YPBottomPager: UIViewController, UIScrollViewDelegate {
     }
     
     func reload() {
-        let viewWidth: CGFloat = UIScreen.main.bounds.width
+        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
+        let viewWidth: CGFloat = hack_ScreenWidth
         for (index, c) in controllers.enumerated() {
             c.willMove(toParent: self)
             addChild(c)
@@ -87,7 +88,8 @@ open class YPBottomPager: UIViewController, UIScrollViewDelegate {
     }
     
     func showPage(_ page: Int, animated: Bool = true) {
-        let x = CGFloat(page) * UIScreen.main.bounds.width
+        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
+        let x = CGFloat(page) * hack_ScreenWidth
         v.scrollView.setContentOffset(CGPoint(x: x, y: 0), animated: animated)
         selectPage(page)
     }
@@ -110,7 +112,8 @@ open class YPBottomPager: UIViewController, UIScrollViewDelegate {
     
     func startOnPage(_ page: Int) {
         currentPage = page
-        let x = CGFloat(page) * UIScreen.main.bounds.width
+        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
+        let x = CGFloat(page) * hack_ScreenWidth
         v.scrollView.setContentOffset(CGPoint(x: x, y: 0), animated: false)
         //select menut item and deselect others
         for mi in v.header.menuItems {

--- a/Source/Pages/Gallery/BottomPager/YPBottomPager.swift
+++ b/Source/Pages/Gallery/BottomPager/YPBottomPager.swift
@@ -49,8 +49,8 @@ open class YPBottomPager: UIViewController, UIScrollViewDelegate {
     }
     
     func reload() {
-        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
-        let viewWidth: CGFloat = hack_ScreenWidth
+        let screenWidth = YPImagePickerConfiguration.screenWidth
+        let viewWidth: CGFloat = screenWidth
         for (index, c) in controllers.enumerated() {
             c.willMove(toParent: self)
             addChild(c)
@@ -88,8 +88,8 @@ open class YPBottomPager: UIViewController, UIScrollViewDelegate {
     }
     
     func showPage(_ page: Int, animated: Bool = true) {
-        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
-        let x = CGFloat(page) * hack_ScreenWidth
+        let screenWidth = YPImagePickerConfiguration.screenWidth
+        let x = CGFloat(page) * screenWidth
         v.scrollView.setContentOffset(CGPoint(x: x, y: 0), animated: animated)
         selectPage(page)
     }
@@ -112,8 +112,8 @@ open class YPBottomPager: UIViewController, UIScrollViewDelegate {
     
     func startOnPage(_ page: Int) {
         currentPage = page
-        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
-        let x = CGFloat(page) * hack_ScreenWidth
+        let screenWidth = YPImagePickerConfiguration.screenWidth
+        let x = CGFloat(page) * screenWidth
         v.scrollView.setContentOffset(CGPoint(x: x, y: 0), animated: false)
         //select menut item and deselect others
         for mi in v.header.menuItems {

--- a/Source/Pages/Gallery/BottomPager/YPPagerMenu.swift
+++ b/Source/Pages/Gallery/BottomPager/YPPagerMenu.swift
@@ -23,7 +23,8 @@ final class YPPagerMenu: UIView {
     var separators = [UIView]()
     
     func setUpMenuItemsConstraints() {
-        let menuItemWidth: CGFloat = UIScreen.main.bounds.width / CGFloat(menuItems.count)
+        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
+        let menuItemWidth: CGFloat = hack_ScreenWidth / CGFloat(menuItems.count)
         var previousMenuItem: YPMenuItem?
         for m in menuItems {
             sv(

--- a/Source/Pages/Gallery/BottomPager/YPPagerMenu.swift
+++ b/Source/Pages/Gallery/BottomPager/YPPagerMenu.swift
@@ -23,8 +23,8 @@ final class YPPagerMenu: UIView {
     var separators = [UIView]()
     
     func setUpMenuItemsConstraints() {
-        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
-        let menuItemWidth: CGFloat = hack_ScreenWidth / CGFloat(menuItems.count)
+        let screenWidth = YPImagePickerConfiguration.screenWidth
+        let menuItemWidth: CGFloat = screenWidth / CGFloat(menuItems.count)
         var previousMenuItem: YPMenuItem?
         for m in menuItems {
             sv(

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -30,7 +30,8 @@ class LibraryMediaManager {
     }
     
     func updateCachedAssets(in collectionView: UICollectionView) {
-        let size = UIScreen.main.bounds.width/4 * UIScreen.main.scale
+        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
+        let size = hack_ScreenWidth / 4 * UIScreen.main.scale
         let cellSize = CGSize(width: size, height: size)
         
         var preheatRect = collectionView.bounds

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -30,8 +30,8 @@ class LibraryMediaManager {
     }
     
     func updateCachedAssets(in collectionView: UICollectionView) {
-        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
-        let size = hack_ScreenWidth / 4 * UIScreen.main.scale
+        var screenWidth = YPImagePickerConfiguration.screenWidth
+        let size = screenWidth / 4 * UIScreen.main.scale
         let cellSize = CGSize(width: size, height: size)
         
         var preheatRect = collectionView.bounds

--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -142,7 +142,8 @@ final class YPAssetZoomableView: UIScrollView {
         self.zoomScale = 1
         
         // Calculating and setting the image view frame depending on screenWidth
-        let screenWidth: CGFloat = UIScreen.main.bounds.width
+        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
+        let screenWidth: CGFloat = hack_ScreenWidth
         let w = image.size.width
         let h = image.size.height
 

--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -142,8 +142,9 @@ final class YPAssetZoomableView: UIScrollView {
         self.zoomScale = 1
         
         // Calculating and setting the image view frame depending on screenWidth
-        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
-        let screenWidth: CGFloat = hack_ScreenWidth
+        var screenWidth = YPImagePickerConfiguration.screenWidth
+        
+        
         let w = image.size.width
         let h = image.size.height
 

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -157,8 +157,11 @@ extension YPLibraryView {
     }
     
     func cellSize() -> CGSize {
-        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
-        let size = hack_ScreenWidth / 4 * UIScreen.main.scale
+        var screenWidth : CGFloat = UIScreen.main.bounds.width
+        if UIDevice.current.userInterfaceIdiom == .pad && YPImagePickerConfiguration.widthOniPad > 0 {
+            screenWidth =  YPImagePickerConfiguration.widthOniPad
+        }
+        let size = screenWidth / 4 * UIScreen.main.scale
         return CGSize(width: size, height: size)
     }
 }

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -157,7 +157,8 @@ extension YPLibraryView {
     }
     
     func cellSize() -> CGSize {
-        let size = UIScreen.main.bounds.width/4 * UIScreen.main.scale
+        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
+        let size = hack_ScreenWidth / 4 * UIScreen.main.scale
         return CGSize(width: size, height: size)
     }
 }

--- a/Source/SelectionsGallery/YPSelectionsGalleryView.swift
+++ b/Source/SelectionsGallery/YPSelectionsGalleryView.swift
@@ -47,7 +47,8 @@ class YPGalleryCollectionViewFlowLayout: UICollectionViewFlowLayout {
         let overlapppingNextPhoto: CGFloat = 37
         minimumLineSpacing = spacing
         minimumInteritemSpacing = spacing
-        let size = UIScreen.main.bounds.width - (sideMargin + overlapppingNextPhoto)
+        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
+        let size = hack_ScreenWidth - (sideMargin + overlapppingNextPhoto)
         itemSize = CGSize(width: size, height: size)
         sectionInset = UIEdgeInsets(top: 0, left: sideMargin, bottom: 0, right: sideMargin)
     }

--- a/Source/SelectionsGallery/YPSelectionsGalleryView.swift
+++ b/Source/SelectionsGallery/YPSelectionsGalleryView.swift
@@ -47,8 +47,8 @@ class YPGalleryCollectionViewFlowLayout: UICollectionViewFlowLayout {
         let overlapppingNextPhoto: CGFloat = 37
         minimumLineSpacing = spacing
         minimumInteritemSpacing = spacing
-        let hack_ScreenWidth : CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 500 : UIScreen.main.bounds.width
-        let size = hack_ScreenWidth - (sideMargin + overlapppingNextPhoto)
+        let screenWidth = YPImagePickerConfiguration.screenWidth
+        let size = screenWidth - (sideMargin + overlapppingNextPhoto)
         itemSize = CGSize(width: size, height: size)
         sectionInset = UIEdgeInsets(top: 0, left: sideMargin, bottom: 0, right: sideMargin)
     }


### PR DESCRIPTION
Hello - first of all - thank you for making amazing lib!
I'm using it in my project and had to hack the solution for displaying it on the iPad.

This PR introduces new static property in the configuration. Width for iPad. It allows user to set the width to say 500, and then display picker in popups or dialogs.

Usage from my code:
```
        imagePicker.preferredContentSize = CGSize(width: 500, height: 600);
        YPImagePickerConfiguration.widthOniPad = imagePicker.preferredContentSize.width;

        [self showInDialog:imagePicker];
```

I've been using this for a while now, and just recently broke the app because of pods update :D so think it would be nice to have even hacky way to make it work for iPad

