### PR TITLE
Add auto trim for videos from device library using trimmerMaxDuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # OS X
 .DS_Store
 
+# AppCode
+.idea/
+
 # Xcode
 build/
 *.pbxuser

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -16,86 +16,86 @@ internal var YPConfig: YPImagePickerConfiguration { return YPImagePickerConfigur
 
 public struct YPImagePickerConfiguration {
     public static var shared: YPImagePickerConfiguration = YPImagePickerConfiguration()
-    
+
     public init() {}
-    
+
     /// Scroll to change modes, defaults to true
     public var isScrollToChangeModesEnabled = true
-    
+
     // Library configuration
     public var library = YPConfigLibrary()
-    
+
     // Video configuration
     public var video = YPConfigVideo()
-    
+
     // Gallery configuration
     public var gallery = YPConfigSelectionsGallery()
-    
+
     /// Use this property to modify the default wordings provided.
     public var wordings = YPWordings()
-    
+
     /// Use this property to modify the default icons provided.
     public var icons = YPIcons()
-    
+
     /// Use this property to modify the default colors provided.
     public var colors = YPColors()
-    
+
     /// Set this to true if you want to force the camera output to be a squared image. Defaults to true
     public var onlySquareImagesFromCamera = true
-    
+
     /// Enables selecting the front camera by default, useful for avatars. Defaults to false
     public var usesFrontCamera = false
-    
+
     /// Adds a Filter step in the photo taking process.  Defaults to true
     public var showsPhotoFilters = true
-    
+
     /// Adds a Video Trimmer step in the video taking process.  Defaults to true
     public var showsVideoTrimmer = true
-    
+
     /// Enables you to opt out from saving new (or old but filtered) images to the
     /// user's photo library. Defaults to true.
     public var shouldSaveNewPicturesToAlbum = true
-    
+
     /// Defines the name of the album when saving pictures in the user's photo library.
     /// In general that would be your App name. Defaults to "DefaultYPImagePickerAlbumName"
     public var albumName = "DefaultYPImagePickerAlbumName"
-    
+
     /// Defines which screen is shown at launch. Video mode will only work if `showsVideo = true`.
     /// Default value is `.photo`
     public var startOnScreen: YPPickerScreen = .photo
-    
+
     /// Defines which screens are shown at launch, and their order.
     /// Default value is `[.library, .photo]`
     public var screens: [YPPickerScreen] = [.library, .photo]
 
     /// Adds a Crop step in the photo taking process, after filters.  Defaults to .none
     public var showsCrop: YPCropType = .none
-    
+
     /// Ex: cappedTo:1024 will make sure images from the library or the camera will be
     /// resized to fit in a 1024x1024 box. Defaults to original image size.
     public var targetImageSize = YPImageSize.original
-    
+
     /// Adds a Overlay View to the camera
     public var overlayView: UIView?
-    
+
     /// Defines if the status bar should be hidden when showing the picker. Default is true
     public var hidesStatusBar = true
-    
+
     /// Defines if the bottom bar should be hidden when showing the picker. Default is false.
     public var hidesBottomBar = false
 
     /// Defines the preferredStatusBarAppearance
     public var preferredStatusBarStyle = UIStatusBarStyle.default
-    
+
     /// Defines the text colour to be shown when a bottom option is selected
     public var bottomMenuItemSelectedTextColour: UIColor = .ypLabel
-    
+
     /// Defines the text colour to be shown when a bottom option is unselected
     public var bottomMenuItemUnSelectedTextColour: UIColor = .ypSecondaryLabel
-    
+
     /// Defines the max camera zoom factor for camera. Disable camera zoom with 1. Default is 1.
     public var maxCameraZoomFactor: CGFloat = 1.0
-    
+
     /// List of default filters which will be added on the filter screen
     public var filters: [YPFilter] = [
         YPFilter(name: "Normal", applier: nil),
@@ -116,64 +116,64 @@ public struct YPImagePickerConfiguration {
         YPFilter(name: "Linear", coreImageFilterName: "CISRGBToneCurveToLinear"),
         YPFilter(name: "Sepia", coreImageFilterName: "CISepiaTone"),
         ]
-    
+
     /// Migration
-    
+
     @available(iOS, obsoleted: 3.0.0, renamed: "video.compression")
     public var videoCompression: String = AVAssetExportPresetHighestQuality
-    
+
     @available(iOS, obsoleted: 3.0.0, renamed: "video.fileType")
     public var videoExtension: AVFileType = .mov
-    
+
     @available(iOS, obsoleted: 3.0.0, renamed: "video.recordingTimeLimit")
     public var videoRecordingTimeLimit: TimeInterval = 60.0
-    
+
     @available(iOS, obsoleted: 3.0.0, renamed: "video.libraryTimeLimit")
     public var videoFromLibraryTimeLimit: TimeInterval = 60.0
-    
+
     @available(iOS, obsoleted: 3.0.0, renamed: "video.minimumTimeLimit")
     public var videoMinimumTimeLimit: TimeInterval = 3.0
-    
+
     @available(iOS, obsoleted: 3.0.0, renamed: "video.trimmerMaxDuration")
     public var trimmerMaxDuration: Double = 60.0
 
     @available(iOS, obsoleted: 3.0.0, renamed: "video.trimmerMinDuration")
     public var trimmerMinDuration: Double = 3.0
-    
+
     @available(iOS, obsoleted: 3.0.0, renamed: "library.onlySquare")
     public var onlySquareImagesFromLibrary = false
-    
+
     @available(iOS, obsoleted: 3.0.0, renamed: "library.onlySquare")
     public var onlySquareFromLibrary = false
-    
+
     @available(iOS, obsoleted: 3.0.0, renamed: "targetImageSize")
     public var libraryTargetImageSize = YPImageSize.original
-    
+
     @available(iOS, obsoleted: 3.0.0, renamed: "library.mediaType")
     public var showsVideoInLibrary = false
-    
+
     @available(iOS, obsoleted: 3.0.0, renamed: "library.mediaType")
     public var libraryMediaType = YPlibraryMediaType.photo
-    
+
     @available(iOS, obsoleted: 3.0.0, renamed: "library.maxNumberOfItems")
     public var maxNumberOfItems = 1
-    
+
 }
 
 /// Encapsulates library specific settings.
 public struct YPConfigLibrary {
-    
+
     public var options: PHFetchOptions? = nil
 
     /// Set this to true if you want to force the library output to be a squared image. Defaults to false.
     public var onlySquare = false
-    
+
     /// Sets the cropping style to square or not. Ignored if `onlySquare` is true. Defaults to true.
     public var isSquareByDefault = true
-    
+
     /// Minimum width, to prevent selectiong too high images. Have sense if onlySquare is true and the image is portrait.
     public var minWidthForItem: CGFloat?
-    
+
     /// Choose what media types are available in the library. Defaults to `.photo`
     public var mediaType = YPlibraryMediaType.photo
 
@@ -182,7 +182,7 @@ public struct YPConfigLibrary {
 
     /// Anything superior than 1 will enable the multiple selection feature.
     public var maxNumberOfItems = 1
-    
+
     /// Anything greater than 1 will desactivate live photo and video modes (library only) and
     // force users to select at least the number of items defined.
     public var minNumberOfItems = 1
@@ -195,14 +195,14 @@ public struct YPConfigLibrary {
 
     /// Allow to skip the selections gallery when selecting the multiple media items. Defaults to false.
     public var skipSelectionsGallery = false
-    
+
     /// Allow to preselected media items
     public var preselectedItems: [YPMediaItem]?
 }
 
 /// Encapsulates video specific settings.
 public struct YPConfigVideo {
-    
+
     /** Choose the videoCompression. Defaults to AVAssetExportPresetHighestQuality
      - "AVAssetExportPresetLowQuality"
      - "AVAssetExportPreset640x480"
@@ -216,28 +216,34 @@ public struct YPConfigVideo {
      - "AVAssetExportPresetPassthrough" // without any compression
      */
     public var compression: String = AVAssetExportPresetHighestQuality
-    
+
     /// Choose the result video extension if you trim or compress a video. Defaults to mov.
     public var fileType: AVFileType = .mov
-    
+
     /// Defines the time limit for recording videos.
     /// Default is 60 seconds.
     public var recordingTimeLimit: TimeInterval = 60.0
-    
+
     /// Defines the time limit for videos from the library.
     /// Defaults to 60 seconds.
     public var libraryTimeLimit: TimeInterval = 60.0
-    
+
     /// Defines the minimum time for the video
     /// Defaults to 3 seconds.
     public var minimumTimeLimit: TimeInterval = 3.0
-    
+
     /// The maximum duration allowed for the trimming. Change it before setting the asset, as the asset preview
+    /// - Tag: trimmerMaxDuration
     public var trimmerMaxDuration: Double = 60.0
-    
+
     /// The minimum duration allowed for the trimming.
     /// The handles won't pan further if the minimum duration is attained.
     public var trimmerMinDuration: Double = 3.0
+
+    /// Defines if the user skips the trimer stage, the video will be trimmed automatically to the maximum value of trimmerMaxDuration
+    /// This case occurs when the user already has a video selected and enables a multiselection to pick more than one type of media (video or image), so, the trimmer step becomes optional.
+    /// - SeeAlso: [trimmerMaxDuration](x-source-tag://trimmerMaxDuration)
+    public var automaticTrimToTrimmerMaxDuration: Bool = false
 }
 
 /// Encapsulates gallery specific settings.

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -67,7 +67,7 @@ public struct YPImagePickerConfiguration {
     /// Defines which screens are shown at launch, and their order.
     /// Default value is `[.library, .photo]`
     public var screens: [YPPickerScreen] = [.library, .photo]
-    
+
     /// Adds a Crop step in the photo taking process, after filters.  Defaults to .none
     public var showsCrop: YPCropType = .none
     
@@ -83,7 +83,7 @@ public struct YPImagePickerConfiguration {
     
     /// Defines if the bottom bar should be hidden when showing the picker. Default is false.
     public var hidesBottomBar = false
-    
+
     /// Defines the preferredStatusBarAppearance
     public var preferredStatusBarStyle = UIStatusBarStyle.default
     
@@ -116,7 +116,7 @@ public struct YPImagePickerConfiguration {
         YPFilter(name: "Linear", coreImageFilterName: "CISRGBToneCurveToLinear"),
         YPFilter(name: "Sepia", coreImageFilterName: "CISepiaTone"),
         ]
-
+    
     /// Migration
     
     @available(iOS, obsoleted: 3.0.0, renamed: "video.compression")
@@ -136,7 +136,7 @@ public struct YPImagePickerConfiguration {
     
     @available(iOS, obsoleted: 3.0.0, renamed: "video.trimmerMaxDuration")
     public var trimmerMaxDuration: Double = 60.0
-    
+
     @available(iOS, obsoleted: 3.0.0, renamed: "video.trimmerMinDuration")
     public var trimmerMinDuration: Double = 3.0
     
@@ -164,7 +164,7 @@ public struct YPImagePickerConfiguration {
 public struct YPConfigLibrary {
     
     public var options: PHFetchOptions? = nil
-    
+
     /// Set this to true if you want to force the library output to be a squared image. Defaults to false.
     public var onlySquare = false
     
@@ -176,23 +176,23 @@ public struct YPConfigLibrary {
     
     /// Choose what media types are available in the library. Defaults to `.photo`
     public var mediaType = YPlibraryMediaType.photo
-    
+
     /// Initial state of multiple selection button.
     public var defaultMultipleSelection = false
-    
+
     /// Anything superior than 1 will enable the multiple selection feature.
     public var maxNumberOfItems = 1
     
     /// Anything greater than 1 will desactivate live photo and video modes (library only) and
     // force users to select at least the number of items defined.
     public var minNumberOfItems = 1
-    
+
     /// Set the number of items per row in collection view. Defaults to 4.
     public var numberOfItemsInRow: Int = 4
-    
+
     /// Set the spacing between items in collection view. Defaults to 1.0.
     public var spacingBetweenItems: CGFloat = 1.0
-    
+
     /// Allow to skip the selections gallery when selecting the multiple media items. Defaults to false.
     public var skipSelectionsGallery = false
     

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -16,86 +16,86 @@ internal var YPConfig: YPImagePickerConfiguration { return YPImagePickerConfigur
 
 public struct YPImagePickerConfiguration {
     public static var shared: YPImagePickerConfiguration = YPImagePickerConfiguration()
-
+    
     public init() {}
-
+    
     /// Scroll to change modes, defaults to true
     public var isScrollToChangeModesEnabled = true
-
+    
     // Library configuration
     public var library = YPConfigLibrary()
-
+    
     // Video configuration
     public var video = YPConfigVideo()
-
+    
     // Gallery configuration
     public var gallery = YPConfigSelectionsGallery()
-
+    
     /// Use this property to modify the default wordings provided.
     public var wordings = YPWordings()
-
+    
     /// Use this property to modify the default icons provided.
     public var icons = YPIcons()
-
+    
     /// Use this property to modify the default colors provided.
     public var colors = YPColors()
-
+    
     /// Set this to true if you want to force the camera output to be a squared image. Defaults to true
     public var onlySquareImagesFromCamera = true
-
+    
     /// Enables selecting the front camera by default, useful for avatars. Defaults to false
     public var usesFrontCamera = false
-
+    
     /// Adds a Filter step in the photo taking process.  Defaults to true
     public var showsPhotoFilters = true
-
+    
     /// Adds a Video Trimmer step in the video taking process.  Defaults to true
     public var showsVideoTrimmer = true
-
+    
     /// Enables you to opt out from saving new (or old but filtered) images to the
     /// user's photo library. Defaults to true.
     public var shouldSaveNewPicturesToAlbum = true
-
+    
     /// Defines the name of the album when saving pictures in the user's photo library.
     /// In general that would be your App name. Defaults to "DefaultYPImagePickerAlbumName"
     public var albumName = "DefaultYPImagePickerAlbumName"
-
+    
     /// Defines which screen is shown at launch. Video mode will only work if `showsVideo = true`.
     /// Default value is `.photo`
     public var startOnScreen: YPPickerScreen = .photo
-
+    
     /// Defines which screens are shown at launch, and their order.
     /// Default value is `[.library, .photo]`
     public var screens: [YPPickerScreen] = [.library, .photo]
-
+    
     /// Adds a Crop step in the photo taking process, after filters.  Defaults to .none
     public var showsCrop: YPCropType = .none
-
+    
     /// Ex: cappedTo:1024 will make sure images from the library or the camera will be
     /// resized to fit in a 1024x1024 box. Defaults to original image size.
     public var targetImageSize = YPImageSize.original
-
+    
     /// Adds a Overlay View to the camera
     public var overlayView: UIView?
-
+    
     /// Defines if the status bar should be hidden when showing the picker. Default is true
     public var hidesStatusBar = true
-
+    
     /// Defines if the bottom bar should be hidden when showing the picker. Default is false.
     public var hidesBottomBar = false
-
+    
     /// Defines the preferredStatusBarAppearance
     public var preferredStatusBarStyle = UIStatusBarStyle.default
-
+    
     /// Defines the text colour to be shown when a bottom option is selected
     public var bottomMenuItemSelectedTextColour: UIColor = .ypLabel
-
+    
     /// Defines the text colour to be shown when a bottom option is unselected
     public var bottomMenuItemUnSelectedTextColour: UIColor = .ypSecondaryLabel
-
+    
     /// Defines the max camera zoom factor for camera. Disable camera zoom with 1. Default is 1.
     public var maxCameraZoomFactor: CGFloat = 1.0
-
+    
     /// List of default filters which will be added on the filter screen
     public var filters: [YPFilter] = [
         YPFilter(name: "Normal", applier: nil),
@@ -118,91 +118,91 @@ public struct YPImagePickerConfiguration {
         ]
 
     /// Migration
-
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "video.compression")
     public var videoCompression: String = AVAssetExportPresetHighestQuality
-
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "video.fileType")
     public var videoExtension: AVFileType = .mov
-
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "video.recordingTimeLimit")
     public var videoRecordingTimeLimit: TimeInterval = 60.0
-
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "video.libraryTimeLimit")
     public var videoFromLibraryTimeLimit: TimeInterval = 60.0
-
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "video.minimumTimeLimit")
     public var videoMinimumTimeLimit: TimeInterval = 3.0
-
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "video.trimmerMaxDuration")
     public var trimmerMaxDuration: Double = 60.0
-
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "video.trimmerMinDuration")
     public var trimmerMinDuration: Double = 3.0
-
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "library.onlySquare")
     public var onlySquareImagesFromLibrary = false
-
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "library.onlySquare")
     public var onlySquareFromLibrary = false
-
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "targetImageSize")
     public var libraryTargetImageSize = YPImageSize.original
-
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "library.mediaType")
     public var showsVideoInLibrary = false
-
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "library.mediaType")
     public var libraryMediaType = YPlibraryMediaType.photo
-
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "library.maxNumberOfItems")
     public var maxNumberOfItems = 1
-
+    
 }
 
 /// Encapsulates library specific settings.
 public struct YPConfigLibrary {
-
+    
     public var options: PHFetchOptions? = nil
-
+    
     /// Set this to true if you want to force the library output to be a squared image. Defaults to false.
     public var onlySquare = false
-
+    
     /// Sets the cropping style to square or not. Ignored if `onlySquare` is true. Defaults to true.
     public var isSquareByDefault = true
-
+    
     /// Minimum width, to prevent selectiong too high images. Have sense if onlySquare is true and the image is portrait.
     public var minWidthForItem: CGFloat?
-
+    
     /// Choose what media types are available in the library. Defaults to `.photo`
     public var mediaType = YPlibraryMediaType.photo
-
+    
     /// Initial state of multiple selection button.
     public var defaultMultipleSelection = false
-
+    
     /// Anything superior than 1 will enable the multiple selection feature.
     public var maxNumberOfItems = 1
-
+    
     /// Anything greater than 1 will desactivate live photo and video modes (library only) and
     // force users to select at least the number of items defined.
     public var minNumberOfItems = 1
-
+    
     /// Set the number of items per row in collection view. Defaults to 4.
     public var numberOfItemsInRow: Int = 4
-
+    
     /// Set the spacing between items in collection view. Defaults to 1.0.
     public var spacingBetweenItems: CGFloat = 1.0
-
+    
     /// Allow to skip the selections gallery when selecting the multiple media items. Defaults to false.
     public var skipSelectionsGallery = false
-
+    
     /// Allow to preselected media items
     public var preselectedItems: [YPMediaItem]?
 }
 
 /// Encapsulates video specific settings.
 public struct YPConfigVideo {
-
+    
     /** Choose the videoCompression. Defaults to AVAssetExportPresetHighestQuality
      - "AVAssetExportPresetLowQuality"
      - "AVAssetExportPreset640x480"
@@ -216,30 +216,30 @@ public struct YPConfigVideo {
      - "AVAssetExportPresetPassthrough" // without any compression
      */
     public var compression: String = AVAssetExportPresetHighestQuality
-
+    
     /// Choose the result video extension if you trim or compress a video. Defaults to mov.
     public var fileType: AVFileType = .mov
-
+    
     /// Defines the time limit for recording videos.
     /// Default is 60 seconds.
     public var recordingTimeLimit: TimeInterval = 60.0
-
+    
     /// Defines the time limit for videos from the library.
     /// Defaults to 60 seconds.
     public var libraryTimeLimit: TimeInterval = 60.0
-
+    
     /// Defines the minimum time for the video
     /// Defaults to 3 seconds.
     public var minimumTimeLimit: TimeInterval = 3.0
-
+    
     /// The maximum duration allowed for the trimming. Change it before setting the asset, as the asset preview
     /// - Tag: trimmerMaxDuration
     public var trimmerMaxDuration: Double = 60.0
-
+    
     /// The minimum duration allowed for the trimming.
     /// The handles won't pan further if the minimum duration is attained.
     public var trimmerMinDuration: Double = 3.0
-
+    
     /// Defines if the user skips the trimer stage, the video will be trimmed automatically to the maximum value of trimmerMaxDuration
     /// This case occurs when the user already has a video selected and enables a multiselection to pick more than one type of media (video or image), so, the trimmer step becomes optional.
     /// - SeeAlso: [trimmerMaxDuration](x-source-tag://trimmerMaxDuration)

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -32,16 +32,16 @@ class LibraryMediaManager {
     func updateCachedAssets(in collectionView: UICollectionView) {
         let size = UIScreen.main.bounds.width/4 * UIScreen.main.scale
         let cellSize = CGSize(width: size, height: size)
-
+        
         var preheatRect = collectionView.bounds
         preheatRect = preheatRect.insetBy(dx: 0.0, dy: -0.5 * preheatRect.height)
-
+        
         let delta = abs(preheatRect.midY - previousPreheatRect.midY)
         if delta > collectionView.bounds.height / 3.0 {
-
+            
             var addedIndexPaths: [IndexPath] = []
             var removedIndexPaths: [IndexPath] = []
-
+            
             previousPreheatRect.differenceWith(rect: preheatRect, removedHandler: { removedRect in
                 let indexPaths = collectionView.aapl_indexPathsForElementsInRect(removedRect)
                 removedIndexPaths += indexPaths
@@ -49,10 +49,10 @@ class LibraryMediaManager {
                 let indexPaths = collectionView.aapl_indexPathsForElementsInRect(addedRect)
                 addedIndexPaths += indexPaths
             })
-
+            
             let assetsToStartCaching = fetchResult.assetsAtIndexPaths(addedIndexPaths)
             let assetsToStopCaching = fetchResult.assetsAtIndexPaths(removedIndexPaths)
-
+            
             imageManager?.startCachingImages(for: assetsToStartCaching,
                                              targetSize: cellSize,
                                              contentMode: .aspectFill,
@@ -154,7 +154,7 @@ class LibraryMediaManager {
                                     }
                                 }
                 }
-                
+
                 // 6. Exporting
                 DispatchQueue.main.async {
                     self.exportTimer = Timer.scheduledTimer(timeInterval: 0.1,
@@ -163,7 +163,7 @@ class LibraryMediaManager {
                                                             userInfo: exportSession,
                                                             repeats: true)
                 }
-                
+
                 if let s = exportSession {
                     self.currentExportSessions.append(s)
                 }
@@ -190,7 +190,7 @@ class LibraryMediaManager {
                     v.updateProgress(exportSession.progress)
                 }
             }
-
+            
             if exportSession.progress > 0.99 {
                 sender.invalidate()
                 v?.updateProgress(0)

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -21,7 +21,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
     internal let mediaManager = LibraryMediaManager()
     internal var latestImageTapped = ""
     internal let panGestureHelper = PanGestureHelper()
-    
+
     // MARK: - Init
     
     public required init(items: [YPMediaItem]?) {
@@ -50,7 +50,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
     func initialize() {
         mediaManager.initialize()
         mediaManager.v = v
-        
+
         if mediaManager.fetchResult != nil {
             return
         }
@@ -60,7 +60,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         panGestureHelper.registerForPanGesture(on: v)
         registerForTapOnPreview()
         refreshMediaRequest()
-        
+
         if YPConfig.library.defaultMultipleSelection {
             multipleSelectionButtonTapped()
         }
@@ -83,13 +83,13 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                 // The negative index will be corrected in the collectionView:cellForItemAt:
                 return YPLibrarySelection(index: -1, assetIdentifier: asset.localIdentifier)
             }
-            
+
             multipleSelectionEnabled = selection.count > 1
             v.assetViewContainer.setMultipleSelectionMode(on: multipleSelectionEnabled)
             v.collectionView.reloadData()
         }
     }
-
+    
     // MARK: - View Lifecycle
     
     public override func loadView() {
@@ -107,11 +107,11 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             guard let strongSelf = self else {
                 return
             }
-            
+
             strongSelf.updateCropInfo()
         }
     }
-
+    
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
@@ -136,7 +136,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             multipleSelectionButtonTapped()
         }
     }
-
+    
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
@@ -144,7 +144,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         NotificationCenter.default.removeObserver(self)
         PHPhotoLibrary.shared().unregisterChangeObserver(self)
     }
-
+    
     // MARK: - Crop control
     
     @objc
@@ -155,7 +155,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
     }
     
     // MARK: - Multiple Selection
-    
+
     @objc
     func multipleSelectionButtonTapped() {
         doAfterPermissionCheck { [weak self] in
@@ -214,7 +214,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
     }
     
     // MARK: - Permissions
-
+    
     func doAfterPermissionCheck(block:@escaping () -> Void) {
         checkPermissionToAccessPhotoLibrary { hasPermission in
             if hasPermission {
@@ -234,7 +234,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             }
         }
     }
-    
+
     // Async beacause will prompt permission if .notDetermined
     // and ask custom popup if denied.
     func checkPermissionToAccessPhotoLibrary(block: @escaping (Bool) -> Void) {
@@ -387,7 +387,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         selectedAsset.scrollViewContentOffset = v.assetZoomableView.contentOffset
         selectedAsset.scrollViewZoomScale = v.assetZoomableView.zoomScale
         selectedAsset.cropRect = v.currentCropRect()
-
+        
         // Replace
         selection.remove(at: selectedAssetIndex)
         selection.insert(selectedAsset, at: selectedAssetIndex)

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -10,7 +10,7 @@ import UIKit
 import Photos
 
 public class YPLibraryVC: UIViewController, YPPermissionCheckable {
-    
+
     internal weak var delegate: YPLibraryViewDelegate?
     internal var v: YPLibraryView!
     internal var isProcessing = false // true if video or image is in processing state
@@ -23,20 +23,20 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
     internal let panGestureHelper = PanGestureHelper()
 
     // MARK: - Init
-    
+
     public required init(items: [YPMediaItem]?) {
         super.init(nibName: nil, bundle: nil)
         title = YPConfig.wordings.libraryTitle
     }
-    
+
     public convenience init() {
         self.init(items: nil)
     }
-    
+
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     func setAlbum(_ album: YPAlbum) {
         title = album.title
         mediaManager.collection = album.collection
@@ -46,7 +46,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         }
         refreshMediaRequest()
     }
-    
+
     func initialize() {
         mediaManager.initialize()
         mediaManager.v = v
@@ -54,7 +54,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         if mediaManager.fetchResult != nil {
             return
         }
-        
+
         setupCollectionView()
         registerForLibraryChanges()
         panGestureHelper.registerForPanGesture(on: v)
@@ -66,7 +66,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         }
         v.assetViewContainer.multipleSelectionButton.isHidden = !(YPConfig.library.maxNumberOfItems > 1)
         v.maxNumberWarningLabel.text = String(format: YPConfig.wordings.warningMaxItemsLimit, YPConfig.library.maxNumberOfItems)
-        
+
         if let preselectedItems = YPConfig.library.preselectedItems {
             selection = preselectedItems.compactMap { item -> YPLibrarySelection? in
                 var itemAsset: PHAsset?
@@ -79,7 +79,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                 guard let asset = itemAsset else {
                     return nil
                 }
-                
+
                 // The negative index will be corrected in the collectionView:cellForItemAt:
                 return YPLibrarySelection(index: -1, assetIdentifier: asset.localIdentifier)
             }
@@ -89,17 +89,17 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             v.collectionView.reloadData()
         }
     }
-    
+
     // MARK: - View Lifecycle
-    
+
     public override func loadView() {
         v = YPLibraryView.xibView()
         view = v
     }
-    
+
     public override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         // When crop area changes in multiple selection mode,
         // we need to update the scrollView values in order to restore
         // them when user selects a previously selected item.
@@ -111,10 +111,10 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             strongSelf.updateCropInfo()
         }
     }
-    
+
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         v.assetViewContainer.squareCropButton
             .addTarget(self,
                        action: #selector(squareCropButtonTapped),
@@ -123,37 +123,37 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             .addTarget(self,
                        action: #selector(multipleSelectionButtonTapped),
                        for: .touchUpInside)
-        
+
         // Forces assetZoomableView to have a contentSize.
         // otherwise 0 in first selection triggering the bug : "invalid image size 0x0"
         // Also fits the first element to the square if the onlySquareFromLibrary = true
         if !YPConfig.library.onlySquare && v.assetZoomableView.contentSize == CGSize(width: 0, height: 0) {
             v.assetZoomableView.setZoomScale(1, animated: false)
         }
-        
+
         // Activate multiple selection when using `minNumberOfItems`
         if YPConfig.library.minNumberOfItems > 1 {
             multipleSelectionButtonTapped()
         }
     }
-    
+
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        
+
         pausePlayer()
         NotificationCenter.default.removeObserver(self)
         PHPhotoLibrary.shared().unregisterChangeObserver(self)
     }
-    
+
     // MARK: - Crop control
-    
+
     @objc
     func squareCropButtonTapped() {
         doAfterPermissionCheck { [weak self] in
             self?.v.assetViewContainer.squareCropButtonTapped()
         }
     }
-    
+
     // MARK: - Multiple Selection
 
     @objc
@@ -162,17 +162,17 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             self?.showMultipleSelection()
         }
     }
-    
+
     private func showMultipleSelection() {
         if !multipleSelectionEnabled {
             selection.removeAll()
         }
-        
+
         // Prevent desactivating multiple selection when using `minNumberOfItems`
         if YPConfig.library.minNumberOfItems > 1 && multipleSelectionEnabled {
             return
         }
-        
+
         multipleSelectionEnabled = !multipleSelectionEnabled
 
         if multipleSelectionEnabled {
@@ -196,14 +196,14 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         checkLimit()
         delegate?.libraryViewDidToggleMultipleSelection(enabled: multipleSelectionEnabled)
     }
-    
+
     // MARK: - Tap Preview
-    
+
     func registerForTapOnPreview() {
         let tapImageGesture = UITapGestureRecognizer(target: self, action: #selector(tappedImage))
         v.assetViewContainer.addGestureRecognizer(tapImageGesture)
     }
-    
+
     @objc
     func tappedImage() {
         if !panGestureHelper.isImageShown {
@@ -212,9 +212,9 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             v.refreshImageCurtainAlpha()
         }
     }
-    
+
     // MARK: - Permissions
-    
+
     func doAfterPermissionCheck(block:@escaping () -> Void) {
         checkPermissionToAccessPhotoLibrary { hasPermission in
             if hasPermission {
@@ -222,7 +222,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             }
         }
     }
-    
+
     func checkPermission() {
         checkPermissionToAccessPhotoLibrary { [weak self] hasPermission in
             guard let strongSelf = self else {
@@ -260,17 +260,17 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             fatalError()
         }
     }
-    
+
     func refreshMediaRequest() {
-        
+
         let options = buildPHFetchOptions()
-        
+
         if let collection = mediaManager.collection {
             mediaManager.fetchResult = PHAsset.fetchAssets(in: collection, options: options)
         } else {
             mediaManager.fetchResult = PHAsset.fetchAssets(with: options)
         }
-                
+
         if mediaManager.fetchResult.count > 0 {
             changeAsset(mediaManager.fetchResult[0])
             v.collectionView.reloadData()
@@ -285,7 +285,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         }
         scrollToTop()
     }
-    
+
     func buildPHFetchOptions() -> PHFetchOptions {
         // Sorting condition
         if let userOpt = YPConfig.library.options {
@@ -296,24 +296,24 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         options.predicate = YPConfig.library.mediaType.predicate()
         return options
     }
-    
+
     func scrollToTop() {
         tappedImage()
         v.collectionView.contentOffset = CGPoint.zero
     }
-    
+
     // MARK: - ScrollViewDelegate
-    
+
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if scrollView == v.collectionView {
             mediaManager.updateCachedAssets(in: self.v.collectionView)
         }
     }
-    
+
     func changeAsset(_ asset: PHAsset) {
         latestImageTapped = asset.localIdentifier
         delegate?.libraryViewStartedLoadingImage()
-        
+
         let completion = { (isLowResIntermediaryImage: Bool) in
             self.v.hideGrid()
             self.v.assetViewContainer.refreshSquareCropButton()
@@ -323,7 +323,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                 self.delegate?.libraryViewFinishedLoading()
             }
         }
-        
+
         let updateCropInfo = {
             self.updateCropInfo()
         }
@@ -349,17 +349,17 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             }
         }
     }
-    
+
     // MARK: - Verification
-    
+
     private func fitsVideoLengthLimits(asset: PHAsset) -> Bool {
         guard asset.mediaType == .video else {
             return true
         }
-        
+
         let tooLong = floor(asset.duration) > YPConfig.video.libraryTimeLimit
         let tooShort = floor(asset.duration) < YPConfig.video.minimumTimeLimit
-        
+
         if tooLong || tooShort {
             DispatchQueue.main.async {
                 let alert = tooLong ? YPAlert.videoTooLongAlert(self.view) : YPAlert.videoTooShortAlert(self.view)
@@ -367,32 +367,32 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             }
             return false
         }
-        
+
         return true
     }
-    
+
     // MARK: - Stored Crop Position
-    
+
     internal func updateCropInfo(shouldUpdateOnlyIfNil: Bool = false) {
         guard let selectedAssetIndex = selection.firstIndex(where: { $0.index == currentlySelectedIndex }) else {
             return
         }
-        
+
         if shouldUpdateOnlyIfNil && selection[selectedAssetIndex].scrollViewContentOffset != nil {
             return
         }
-        
+
         // Fill new values
         var selectedAsset = selection[selectedAssetIndex]
         selectedAsset.scrollViewContentOffset = v.assetZoomableView.contentOffset
         selectedAsset.scrollViewZoomScale = v.assetZoomableView.zoomScale
         selectedAsset.cropRect = v.currentCropRect()
-        
+
         // Replace
         selection.remove(at: selectedAssetIndex)
         selection.insert(selectedAsset, at: selectedAssetIndex)
     }
-    
+
     internal func fetchStoredCrop() -> YPLibrarySelection? {
         if self.multipleSelectionEnabled,
             self.selection.contains(where: { $0.index == self.currentlySelectedIndex }) {
@@ -404,13 +404,13 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         }
         return nil
     }
-    
+
     internal func hasStoredCrop(index: Int) -> Bool {
         return self.selection.contains(where: { $0.index == index })
     }
-    
+
     // MARK: - Fetching Media
-    
+
     private func fetchImageAndCrop(for asset: PHAsset,
                                    withCropRect: CGRect? = nil,
                                    callback: @escaping (_ photo: UIImage, _ exif: [String : Any]) -> Void) {
@@ -419,51 +419,73 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         let ts = targetSize(for: asset, cropRect: cropRect)
         mediaManager.imageManager?.fetchImage(for: asset, cropRect: cropRect, targetSize: ts, callback: callback)
     }
-    
-    private func checkVideoLengthAndCrop(for asset: PHAsset,
-                                         withCropRect: CGRect? = nil,
-                                         callback: @escaping (_ videoURL: URL?) -> Void) {
-        if fitsVideoLengthLimits(asset: asset) == true {
+
+    private func fetchVideoAndApplySettings(for asset: PHAsset,
+                                            withCropRect rect: CGRect? = nil,
+                                            callback: @escaping (_ videoURL: URL?) -> Void) {
+        let normalizedCropRect = rect ?? DispatchQueue.main.sync { v.currentCropRect() }
+        let ts = targetSize(for: asset, cropRect: normalizedCropRect)
+        let xCrop: CGFloat = normalizedCropRect.origin.x * CGFloat(asset.pixelWidth)
+        let yCrop: CGFloat = normalizedCropRect.origin.y * CGFloat(asset.pixelHeight)
+        let resultCropRect = CGRect(x: xCrop,
+                                    y: yCrop,
+                                    width: ts.width,
+                                    height: ts.height)
+
+        guard fitsVideoLengthLimits(asset: asset) else {
+            return
+        }
+
+        if YPConfig.video.automaticTrimToTrimmerMaxDuration {
+            fetchVideoAndCropWithDuration(for: asset,
+                                          withCropRect: resultCropRect,
+                                          duration: YPConfig.video.trimmerMaxDuration,
+                                          callback: callback)
+        } else {
             delegate?.libraryViewDidTapNext()
-            let normalizedCropRect = withCropRect ?? DispatchQueue.main.sync { v.currentCropRect() }
-            let ts = targetSize(for: asset, cropRect: normalizedCropRect)
-            let xCrop: CGFloat = normalizedCropRect.origin.x * CGFloat(asset.pixelWidth)
-            let yCrop: CGFloat = normalizedCropRect.origin.y * CGFloat(asset.pixelHeight)
-            let resultCropRect = CGRect(x: xCrop,
-                                        y: yCrop,
-                                        width: ts.width,
-                                        height: ts.height)
             mediaManager.fetchVideoUrlAndCrop(for: asset, cropRect: resultCropRect, callback: callback)
         }
     }
-    
+
+    private func fetchVideoAndCropWithDuration(for asset: PHAsset,
+                                               withCropRect rect: CGRect,
+                                               duration: Double,
+                                               callback: @escaping (_ videoURL: URL?) -> Void) {
+        delegate?.libraryViewDidTapNext()
+        let timeDuration = CMTimeMakeWithSeconds(duration, preferredTimescale: 1000)
+        mediaManager.fetchVideoUrlAndCropWithDuration(for: asset,
+                                                      cropRect: rect,
+                                                      duration: timeDuration,
+                                                      callback: callback)
+    }
+
     public func selectedMedia(photoCallback: @escaping (_ photo: YPMediaPhoto) -> Void,
                               videoCallback: @escaping (_ videoURL: YPMediaVideo) -> Void,
                               multipleItemsCallback: @escaping (_ items: [YPMediaItem]) -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
-            
+
             let selectedAssets: [(asset: PHAsset, cropRect: CGRect?)] = self.selection.map {
                 guard let asset = PHAsset.fetchAssets(withLocalIdentifiers: [$0.assetIdentifier], options: PHFetchOptions()).firstObject else { fatalError() }
                 return (asset, $0.cropRect)
             }
-            
+
             // Multiple selection
             if self.multipleSelectionEnabled && self.selection.count > 1 {
-                
+
                 // Check video length
                 for asset in selectedAssets {
                     if self.fitsVideoLengthLimits(asset: asset.asset) == false {
                         return
                     }
                 }
-                
+
                 // Fill result media items array
                 var resultMediaItems: [YPMediaItem] = []
                 let asyncGroup = DispatchGroup()
-                
+
                 for asset in selectedAssets {
                     asyncGroup.enter()
-                    
+
                     switch asset.asset.mediaType {
                     case .image:
                         self.fetchImageAndCrop(for: asset.asset, withCropRect: asset.cropRect) { image, exifMeta in
@@ -471,9 +493,10 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                             resultMediaItems.append(YPMediaItem.photo(p: photo))
                             asyncGroup.leave()
                         }
-                        
+
                     case .video:
-                        self.checkVideoLengthAndCrop(for: asset.asset, withCropRect: asset.cropRect) { videoURL in
+                        self.fetchVideoAndApplySettings(for: asset.asset,
+                                                             withCropRect: asset.cropRect) { videoURL in
                             if let videoURL = videoURL {
                                 let videoItem = YPMediaVideo(thumbnail: thumbnailFromVideoPath(videoURL),
                                                              videoURL: videoURL, asset: asset.asset)
@@ -487,7 +510,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                         break
                     }
                 }
-                
+
                 asyncGroup.notify(queue: .main) {
                     multipleItemsCallback(resultMediaItems)
                     self.delegate?.libraryViewFinishedLoading()
@@ -498,7 +521,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                 case .audio, .unknown:
                     return
                 case .video:
-                    self.checkVideoLengthAndCrop(for: asset, callback: { videoURL in
+                    self.fetchVideoAndApplySettings(for: asset, callback: { videoURL in
                         DispatchQueue.main.async {
                             if let videoURL = videoURL {
                                 self.delegate?.libraryViewFinishedLoading()
@@ -527,9 +550,9 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
             }
         }
     }
-    
+
     // MARK: - TargetSize
-    
+
     private func targetSize(for asset: PHAsset, cropRect: CGRect) -> CGSize {
         var width = (CGFloat(asset.pixelWidth) * cropRect.width).rounded(.toNearestOrEven)
         var height = (CGFloat(asset.pixelHeight) * cropRect.height).rounded(.toNearestOrEven)
@@ -538,15 +561,15 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         height = (height.truncatingRemainder(dividingBy: 2) == 0) ? height : height - 1
         return CGSize(width: width, height: height)
     }
-    
+
     // MARK: - Player
-    
+
     func pausePlayer() {
         v.assetZoomableView.videoView.pause()
     }
-    
+
     // MARK: - Deinit
-    
+
     deinit {
         PHPhotoLibrary.shared().unregisterChangeObserver(self)
     }


### PR DESCRIPTION
This commits adds the request from issue #341. 

This case occurs when the user already has a video selected and enables a multiselection to pick more than one type of media (video or image), so, the trimmer step becomes optional.