### PR TITLE
fix(YPLibraryVC): handle default multiple selection

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -84,7 +84,8 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
                 return YPLibrarySelection(index: -1, assetIdentifier: asset.localIdentifier)
             }
 
-            multipleSelectionEnabled = selection.count > 1
+            // If defaultMultipleSelection is true then enable multiple selection irrespective of number of selected items
+            multipleSelectionEnabled = YPConfig.library.defaultMultipleSelection == true ? true : selection.count > 1
             v.assetViewContainer.setMultipleSelectionMode(on: multipleSelectionEnabled)
             v.collectionView.reloadData()
         }


### PR DESCRIPTION
***Description**:*
If defaultMultipleSelection is true then enable multiple selection irrespective of number of selected items

***Github Issue**:* 
https://github.com/Yummypets/YPImagePicker/issues/524