### PR TITLE
Add a config to pre-select the current item in library when using multiple options

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -180,6 +180,9 @@ public struct YPConfigLibrary {
     /// Initial state of multiple selection button.
     public var defaultMultipleSelection = false
 
+    /// Pre-selects the current item on setting multiple selection
+    public var preSelectItemOnMultipleSelection = true
+
     /// Anything superior than 1 will enable the multiple selection feature.
     public var maxNumberOfItems = 1
     

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -176,7 +176,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         multipleSelectionEnabled = !multipleSelectionEnabled
 
         if multipleSelectionEnabled {
-            if selection.isEmpty {
+            if selection.isEmpty && YPConfig.library.preSelectItemOnMultipleSelection {
                 let asset = mediaManager.fetchResult[currentlySelectedIndex]
                 selection = [
                     YPLibrarySelection(index: currentlySelectedIndex,


### PR DESCRIPTION
The PR will add `preSelectItemOnMultipleSelection` in `YPConfigLibrary`. 

If set to `false` this will disable the default selection of the current item in multiple selection mode. This is particularly useful when launching the picker in library mode with `defaultMultipleSelection` set to `true` and will allow the users to choose their own first item rather than always preselecting the first (most recent) item.