### PR TITLE
Fix for issue #580, Correct compiler error when building with Swift version < 5.3

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -243,9 +243,12 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         // Only intilialize picker if photo permission is Allowed by user.
         let status = PHPhotoLibrary.authorizationStatus()
         switch status {
-        case .authorized,
-             .limited:
+        case .authorized:
             block(true)
+#if compiler(>=5.3)
+        case .limited:
+            block(true)
+#endif
         case .restricted, .denied:
             let popup = YPPermissionDeniedPopup()
             let alert = popup.popup(cancelBlock: {

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -245,7 +245,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         switch status {
         case .authorized:
             block(true)
-#if compiler(>=5.3)
+        #if compiler(>=5.3)
         case .limited:
             block(true)
 #endif

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -248,7 +248,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         #if compiler(>=5.3)
         case .limited:
             block(true)
-#endif
+        #endif
         case .restricted, .denied:
             let popup = YPPermissionDeniedPopup()
             let alert = popup.popup(cancelBlock: {


### PR DESCRIPTION
Since .limited was added in Swift 5.3, the check had to be made against the compiler version instead of the iOS version.