### PR TITLE
iKK/sizelimit

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -144,6 +144,9 @@ public struct YPImagePickerConfiguration {
     @available(iOS, obsoleted: 3.0.0, renamed: "video.recordingTimeLimit")
     public var videoRecordingTimeLimit: TimeInterval = 60.0
     
+    @available(iOS, obsoleted: 3.0.0, renamed: "video.recordingSizeLimit")
+    public var videoRecordingSizeLimit: Double = 0
+    
     @available(iOS, obsoleted: 3.0.0, renamed: "video.libraryTimeLimit")
     public var videoFromLibraryTimeLimit: TimeInterval = 60.0
     
@@ -245,6 +248,10 @@ public struct YPConfigVideo {
     /// Defines the time limit for recording videos.
     /// Default is 60 seconds.
     public var recordingTimeLimit: TimeInterval = 60.0
+    
+    /// Defines the size limit in bytes for recording videos
+    /// Default is 1 GB
+    public var recordingSizeLimit: Double = 0
     
     /// Defines the time limit for videos from the library.
     /// Defaults to 60 seconds.

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -91,8 +91,8 @@ public struct YPImagePickerConfiguration {
     /// Adds a Overlay View to the camera
     public var overlayView: UIView?
 
-	/// Defines if the navigation bar cancel button should be hidden when showing the picker. Default is false
-	public var hidesCancelButton = false
+    /// Defines if the navigation bar cancel button should be hidden when showing the picker. Default is false
+    public var hidesCancelButton = false
     
     /// Defines if the status bar should be hidden when showing the picker. Default is true
     public var hidesStatusBar = true
@@ -143,9 +143,6 @@ public struct YPImagePickerConfiguration {
     
     @available(iOS, obsoleted: 3.0.0, renamed: "video.recordingTimeLimit")
     public var videoRecordingTimeLimit: TimeInterval = 60.0
-    
-    @available(iOS, obsoleted: 3.0.0, renamed: "video.recordingSizeLimit")
-    public var videoRecordingSizeLimit: Double = 0
     
     @available(iOS, obsoleted: 3.0.0, renamed: "video.libraryTimeLimit")
     public var videoFromLibraryTimeLimit: TimeInterval = 60.0

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -247,8 +247,8 @@ public struct YPConfigVideo {
     public var recordingTimeLimit: TimeInterval = 60.0
     
     /// Defines the size limit in bytes for recording videos
-    /// Default is 1 GB
-    public var recordingSizeLimit: Double = 0
+    /// For example: 1 GB
+    public var recordingSizeLimit: Double?
     
     /// Defines the time limit for videos from the library.
     /// Defaults to 60 seconds.
@@ -266,11 +266,11 @@ public struct YPConfigVideo {
     /// The handles won't pan further if the minimum duration is attained.
     public var trimmerMinDuration: Double = 3.0
 
-	/// Defines if the user skips the trimer stage,
-	/// the video will be trimmed automatically to the maximum value of trimmerMaxDuration.
-	/// This case occurs when the user already has a video selected and enables a
-	/// multiselection to pick more than one type of media (video or image),
-	/// so, the trimmer step becomes optional.
+    /// Defines if the user skips the trimer stage,
+    /// the video will be trimmed automatically to the maximum value of trimmerMaxDuration.
+    /// This case occurs when the user already has a video selected and enables a
+    /// multiselection to pick more than one type of media (video or image),
+    /// so, the trimmer step becomes optional.
     /// - SeeAlso: [trimmerMaxDuration](x-source-tag://trimmerMaxDuration)
     public var automaticTrimToTrimmerMaxDuration: Bool = false
 }

--- a/Source/Pages/Video/YPVideoCaptureHelper.swift
+++ b/Source/Pages/Video/YPVideoCaptureHelper.swift
@@ -244,10 +244,16 @@ class YPVideoCaptureHelper: NSObject {
     
     @objc
     func tick() {
-        let timeElapsed = Date().timeIntervalSince(dateVideoStarted)
-        let progress: Float = Float(timeElapsed) / Float(videoRecordingTimeLimit)
+        let timeElapsed = Date().timeIntervalSince(self.dateVideoStarted)
+        var progress: Float = 0.0
+        if YPConfig.video.recordingSizeLimit != 0 {
+            progress = Float(Double(self.outputURL.fileSize) / YPConfig.video.recordingSizeLimit)
+        } else {
+            progress = Float(timeElapsed) / Float(videoRecordingTimeLimit)
+        }
         DispatchQueue.main.async {
             self.videoRecordingProgress?(progress, timeElapsed)
+            if progress > 0.99 { self.stopRecording() }
         }
     }
     

--- a/Source/Pages/Video/YPVideoCaptureHelper.swift
+++ b/Source/Pages/Video/YPVideoCaptureHelper.swift
@@ -246,14 +246,16 @@ class YPVideoCaptureHelper: NSObject {
     func tick() {
         let timeElapsed = Date().timeIntervalSince(self.dateVideoStarted)
         var progress: Float = 0.0
-        if YPConfig.video.recordingSizeLimit != 0 {
-            progress = Float(Double(self.outputURL.fileSize) / YPConfig.video.recordingSizeLimit)
+        if let recordingSizeLimit = YPConfig.video.recordingSizeLimit {
+            progress = Float(Double(self.outputURL.fileSize) / recordingSizeLimit)
         } else {
             progress = Float(timeElapsed) / Float(videoRecordingTimeLimit)
         }
         DispatchQueue.main.async {
             self.videoRecordingProgress?(progress, timeElapsed)
-            if progress > 0.99 { self.stopRecording() }
+            if progress > 0.99 { 
+                self.stopRecording()
+            }
         }
     }
     


### PR DESCRIPTION
In our project we neede a video recording SIZE-limit instead of the existing TIME-limit.

Therefore I created a new video config-option called recordingSizeLimit.

If the user decides to set this video-config, then the recording-sizeLimit applies (instead of the timeLimit).

The reason for our sizeLimit:  We have a backend limitation for videos.
