### PR TITLE
Fix Example project

### DIFF
--- a/YPImagePickerExample/Podfile
+++ b/YPImagePickerExample/Podfile
@@ -1,0 +1,11 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'YPImagePickerExample' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for YPImagePickerExample
+  pod 'YPImagePicker', :path => '../'
+
+end

--- a/YPImagePickerExample/YPImagePickerExample.xcodeproj/project.pbxproj
+++ b/YPImagePickerExample/YPImagePickerExample.xcodeproj/project.pbxproj
@@ -432,7 +432,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2SS5C7GH48;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/../Carthage/Build/iOS",
@@ -441,7 +441,7 @@
 				INFOPLIST_FILE = YPImagePickerExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = nocoffeecode.ypImagePicker;
+				PRODUCT_BUNDLE_IDENTIFIER = test.ypImagePicker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -455,7 +455,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2SS5C7GH48;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/../Carthage/Build/iOS",
@@ -464,7 +464,7 @@
 				INFOPLIST_FILE = YPImagePickerExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = nocoffeecode.ypImagePicker;
+				PRODUCT_BUNDLE_IDENTIFIER = test.ypImagePicker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/YPImagePickerExample/YPImagePickerExample.xcodeproj/project.pbxproj
+++ b/YPImagePickerExample/YPImagePickerExample.xcodeproj/project.pbxproj
@@ -11,59 +11,16 @@
 		99428A0C1E7BE02400B765A9 /* ExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99428A0B1E7BE02400B765A9 /* ExampleViewController.swift */; };
 		99428A111E7BE02400B765A9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 99428A101E7BE02400B765A9 /* Assets.xcassets */; };
 		99428A141E7BE02400B765A9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 99428A121E7BE02400B765A9 /* LaunchScreen.storyboard */; };
-		99428A271E7BE1D600B765A9 /* YPImagePicker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99428A201E7BE04000B765A9 /* YPImagePicker.framework */; };
-		99428A281E7BE1D600B765A9 /* YPImagePicker.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 99428A201E7BE04000B765A9 /* YPImagePicker.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		997127C1208F45B30089272B /* PryntTrimmerView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 997127C0208F45B30089272B /* PryntTrimmerView.framework */; };
-		997A4CD21F4C3DC0009C3703 /* Stevia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 997A4CD11F4C3DC0009C3703 /* Stevia.framework */; };
 		99A052A61F20DF21005600B3 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 99A052A81F20DF21005600B3 /* Localizable.strings */; };
-		99CD962120D173EB009F5084 /* PryntTrimmerView.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 997127C0208F45B30089272B /* PryntTrimmerView.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		99CD962220D173FE009F5084 /* Stevia.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 997A4CD11F4C3DC0009C3703 /* Stevia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E4B8B87ACE0F8D7E7C9E8B2A /* Pods_YPImagePickerExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39ECAC1A4280ED3A66999C55 /* Pods_YPImagePickerExample.framework */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		99428A1F1E7BE04000B765A9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 99428A1B1E7BE04000B765A9 /* YPImagePicker.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 52412A931CA6114A0073C4BE;
-			remoteInfo = YPImagePicker;
-		};
-		99428A211E7BE0DE00B765A9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 99428A1B1E7BE04000B765A9 /* YPImagePicker.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 52412A921CA6114A0073C4BE;
-			remoteInfo = YPImagePicker;
-		};
-		99428A291E7BE1D600B765A9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 99428A1B1E7BE04000B765A9 /* YPImagePicker.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 52412A921CA6114A0073C4BE;
-			remoteInfo = YPImagePicker;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		99428A2B1E7BE1D600B765A9 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				99CD962220D173FE009F5084 /* Stevia.framework in Embed Frameworks */,
-				99CD962120D173EB009F5084 /* PryntTrimmerView.framework in Embed Frameworks */,
-				99428A281E7BE1D600B765A9 /* YPImagePicker.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
+		39ECAC1A4280ED3A66999C55 /* Pods_YPImagePickerExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_YPImagePickerExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B0E1B9D207069630048E95B /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		5F01F9DE20DCC5EA007432E4 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		71524A8C206FD954002F3162 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		96E2AA2442DD86418F1EC0AB /* Pods-YPImagePickerExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YPImagePickerExample.release.xcconfig"; path = "Target Support Files/Pods-YPImagePickerExample/Pods-YPImagePickerExample.release.xcconfig"; sourceTree = "<group>"; };
 		991C0E5520567E1300764131 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		99428A061E7BE02400B765A9 /* YPImagePickerExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = YPImagePickerExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		99428A091E7BE02400B765A9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -71,15 +28,13 @@
 		99428A101E7BE02400B765A9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		99428A131E7BE02400B765A9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		99428A151E7BE02400B765A9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		99428A1B1E7BE04000B765A9 /* YPImagePicker.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = YPImagePicker.xcodeproj; path = ../YPImagePicker.xcodeproj; sourceTree = "<group>"; };
-		997127C0208F45B30089272B /* PryntTrimmerView.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PryntTrimmerView.framework; path = ../Carthage/Build/iOS/PryntTrimmerView.framework; sourceTree = "<group>"; };
-		997A4CD11F4C3DC0009C3703 /* Stevia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Stevia.framework; path = ../Carthage/Build/iOS/Stevia.framework; sourceTree = "<group>"; };
 		998D452620AC8DFA007F8699 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		99A052A91F20DF24005600B3 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		99A052AA1F20DF39005600B3 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		99A052AB1F20DF54005600B3 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		99BEB97B20A9DE5F00FFEB55 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A7B961E020755CF500216346 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
+		AA088D933E881AB26E8E20F0 /* Pods-YPImagePickerExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YPImagePickerExample.debug.xcconfig"; path = "Target Support Files/Pods-YPImagePickerExample/Pods-YPImagePickerExample.debug.xcconfig"; sourceTree = "<group>"; };
 		DF1BD2FC216F8BE500330319 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		E5287F5920B9095F0052153D /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		EB0D6FC3252F1FDC006EE12E /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -91,9 +46,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				997127C1208F45B30089272B /* PryntTrimmerView.framework in Frameworks */,
-				997A4CD21F4C3DC0009C3703 /* Stevia.framework in Frameworks */,
-				99428A271E7BE1D600B765A9 /* YPImagePicker.framework in Frameworks */,
+				E4B8B87ACE0F8D7E7C9E8B2A /* Pods_YPImagePickerExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -103,10 +56,10 @@
 		994289FD1E7BE02400B765A9 = {
 			isa = PBXGroup;
 			children = (
-				99428A1B1E7BE04000B765A9 /* YPImagePicker.xcodeproj */,
 				99428A081E7BE02400B765A9 /* YPImagePickerExample */,
 				99428A071E7BE02400B765A9 /* Products */,
 				99428A231E7BE17800B765A9 /* Frameworks */,
+				EE54722A140A94570BAC950C /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -131,21 +84,22 @@
 			path = YPImagePickerExample;
 			sourceTree = "<group>";
 		};
-		99428A1C1E7BE04000B765A9 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				99428A201E7BE04000B765A9 /* YPImagePicker.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		99428A231E7BE17800B765A9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				997127C0208F45B30089272B /* PryntTrimmerView.framework */,
-				997A4CD11F4C3DC0009C3703 /* Stevia.framework */,
+				39ECAC1A4280ED3A66999C55 /* Pods_YPImagePickerExample.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		EE54722A140A94570BAC950C /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				AA088D933E881AB26E8E20F0 /* Pods-YPImagePickerExample.debug.xcconfig */,
+				96E2AA2442DD86418F1EC0AB /* Pods-YPImagePickerExample.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -155,18 +109,17 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 99428A181E7BE02400B765A9 /* Build configuration list for PBXNativeTarget "YPImagePickerExample" */;
 			buildPhases = (
+				0E6AFEB930B43A581197A0CA /* [CP] Check Pods Manifest.lock */,
 				99428A021E7BE02400B765A9 /* Sources */,
 				99428A031E7BE02400B765A9 /* Frameworks */,
 				99428A041E7BE02400B765A9 /* Resources */,
-				99428A2B1E7BE1D600B765A9 /* Embed Frameworks */,
 				99BEB97920A9BD1300FFEB55 /* Localizations Sanitizer */,
 				9992698324DAA5D7000CAAFC /* SwiftLint */,
+				633BF14194CB6DDF67A45F1E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				99428A221E7BE0DE00B765A9 /* PBXTargetDependency */,
-				99428A2A1E7BE1D600B765A9 /* PBXTargetDependency */,
 			);
 			name = YPImagePickerExample;
 			productName = YPImagePickerExample;
@@ -185,6 +138,7 @@
 				TargetAttributes = {
 					99428A051E7BE02400B765A9 = {
 						CreatedOnToolsVersion = 8.2;
+						DevelopmentTeam = 2SS5C7GH48;
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
@@ -214,28 +168,12 @@
 			mainGroup = 994289FD1E7BE02400B765A9;
 			productRefGroup = 99428A071E7BE02400B765A9 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 99428A1C1E7BE04000B765A9 /* Products */;
-					ProjectRef = 99428A1B1E7BE04000B765A9 /* YPImagePicker.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				99428A051E7BE02400B765A9 /* YPImagePickerExample */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		99428A201E7BE04000B765A9 /* YPImagePicker.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = YPImagePicker.framework;
-			remoteRef = 99428A1F1E7BE04000B765A9 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		99428A041E7BE02400B765A9 /* Resources */ = {
@@ -251,6 +189,50 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0E6AFEB930B43A581197A0CA /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-YPImagePickerExample-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		633BF14194CB6DDF67A45F1E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-YPImagePickerExample/Pods-YPImagePickerExample-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/PryntTrimmerView/PryntTrimmerView.framework",
+				"${BUILT_PRODUCTS_DIR}/SteviaLayout/Stevia.framework",
+				"${BUILT_PRODUCTS_DIR}/YPImagePicker/YPImagePicker.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PryntTrimmerView.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Stevia.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/YPImagePicker.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-YPImagePickerExample/Pods-YPImagePickerExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9992698324DAA5D7000CAAFC /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -296,19 +278,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		99428A221E7BE0DE00B765A9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = YPImagePicker;
-			targetProxy = 99428A211E7BE0DE00B765A9 /* PBXContainerItemProxy */;
-		};
-		99428A2A1E7BE1D600B765A9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = YPImagePicker;
-			targetProxy = 99428A291E7BE1D600B765A9 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		99428A121E7BE02400B765A9 /* LaunchScreen.storyboard */ = {
@@ -458,12 +427,12 @@
 		};
 		99428A191E7BE02400B765A9 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AA088D933E881AB26E8E20F0 /* Pods-YPImagePickerExample.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 2SS5C7GH48;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/../Carthage/Build/iOS",
@@ -472,7 +441,7 @@
 				INFOPLIST_FILE = YPImagePickerExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = test.ypImagePicker;
+				PRODUCT_BUNDLE_IDENTIFIER = nocoffeecode.ypImagePicker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -481,12 +450,12 @@
 		};
 		99428A1A1E7BE02400B765A9 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 96E2AA2442DD86418F1EC0AB /* Pods-YPImagePickerExample.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 2SS5C7GH48;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/../Carthage/Build/iOS",
@@ -495,7 +464,7 @@
 				INFOPLIST_FILE = YPImagePickerExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = test.ypImagePicker;
+				PRODUCT_BUNDLE_IDENTIFIER = nocoffeecode.ypImagePicker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/YPImagePickerExample/YPImagePickerExample.xcworkspace/contents.xcworkspacedata
+++ b/YPImagePickerExample/YPImagePickerExample.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:YPImagePickerExample.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/YPImagePickerExample/YPImagePickerExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/YPImagePickerExample/YPImagePickerExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
- Fix #620 and #623, that Xcode says "Failed to build Stevia and PrintTrimmerView"
- Change the way using libraries in the Example project, from framework to Podfile. It means there a .xcworkspace generated.