### PR TITLE
Support building with carthage `--use-xcframeworks` option

### DIFF
--- a/YPImagePicker.xcodeproj/project.pbxproj
+++ b/YPImagePicker.xcodeproj/project.pbxproj
@@ -846,6 +846,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Carthage/Build",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/Resources",
 					"$(PROJECT_DIR)/Source",
@@ -879,6 +880,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Carthage/Build",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/Resources",
 					"$(PROJECT_DIR)/Source",


### PR DESCRIPTION
carthage 0.37.0 introduced `use-xcframeworks` option.
With this option, built frameworks are put in `Carthage/Build` directory,
which does not contain platform subdirectory.

So `Carthage/Build` directory should be added to `FRAMEWORK_SEARCH_PATHS`