### PR TITLE
[Fixed] Crash caused by multiple select enable when users authorized …

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -130,7 +130,7 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         }
         
         // Activate multiple selection when using `minNumberOfItems`
-        if YPConfig.library.minNumberOfItems > 1 {
+        if YPConfig.library.minNumberOfItems > 1, mediaManager.hasResultItems {
             multipleSelectionButtonTapped()
         }
     }


### PR DESCRIPTION
[Fixed] Crash caused by multiple select enable when users authorized limited access but selected 0 photos
[https://github.com/Yummypets/YPImagePicker/issues/636#issue-808400521](url)