### PR TITLE
Logic behind album options display are connected with sorting strategy.

### DIFF
--- a/Sources/YPImagePicker/YPPickerVC.swift
+++ b/Sources/YPImagePicker/YPPickerVC.swift
@@ -222,38 +222,29 @@ open class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
             label.textColor = navBarTitleColor
         }
         
-        if YPConfig.library.options != nil {
-            titleView.subviews {
-                label
-            }
-            |-(>=8)-label.centerHorizontally()-(>=8)-|
-            align(horizontally: label)
-        } else {
-            let arrow = UIImageView()
-            arrow.image = YPConfig.icons.arrowDownIcon
-            arrow.image = arrow.image?.withRenderingMode(.alwaysTemplate)
-            arrow.tintColor = .ypLabel
-            
-            let attributes = UINavigationBar.appearance().titleTextAttributes
-            if let attributes = attributes, let foregroundColor = attributes[.foregroundColor] as? UIColor {
-                arrow.image = arrow.image?.withRenderingMode(.alwaysTemplate)
-                arrow.tintColor = foregroundColor
-            }
-            
-            let button = UIButton()
-            button.addTarget(self, action: #selector(navBarTapped), for: .touchUpInside)
-            button.setBackgroundColor(UIColor.white.withAlphaComponent(0.5), forState: .highlighted)
-            
-            titleView.subviews {
-                label
-                arrow
-                button
-            }
-            button.fillContainer()
-            |-(>=8)-label.centerHorizontally()-arrow-(>=8)-|
-            align(horizontally: label-arrow)
+        let arrow = UIImageView()
+        arrow.image = YPConfig.icons.arrowDownIcon
+        arrow.image = arrow.image?.withRenderingMode(.alwaysTemplate)
+        arrow.tintColor = .ypLabel
+      
+        let attributes = UINavigationBar.appearance().titleTextAttributes
+        if let attributes = attributes, let foregroundColor = attributes[.foregroundColor] as? UIColor {
+          arrow.image = arrow.image?.withRenderingMode(.alwaysTemplate)
+          arrow.tintColor = foregroundColor
         }
-        
+      
+        let button = UIButton()
+        button.addTarget(self, action: #selector(navBarTapped), for: .touchUpInside)
+        button.setBackgroundColor(UIColor.white.withAlphaComponent(0.5), forState: .highlighted)
+       
+        titleView.subviews {
+          label
+          arrow
+          button
+        }
+        button.fillContainer()
+        |-(>=8)-label.centerHorizontally()-arrow-(>=8)-|
+        align(horizontally: label-arrow)
         label.firstBaselineAnchor.constraint(equalTo: titleView.bottomAnchor, constant: -14).isActive = true
         
         titleView.heightAnchor.constraint(equalToConstant: 40).isActive = true


### PR DESCRIPTION
Hey, I wonder why selecting custom options for a library (e.g. changing the photo sorting strategy) removes the album selection? This PR resolves this issue, please explain me it if possible, Cheers!