### PR TITLE
Disable interaction on YPLibraryView and YPPickerVC while processing media to prevent crash

### DIFF
--- a/Source/Pages/Gallery/YPAssetViewContainer.swift
+++ b/Source/Pages/Gallery/YPAssetViewContainer.swift
@@ -21,6 +21,7 @@ class YPAssetViewContainer: UIView {
     public let multipleSelectionButton = UIButton()
     public var onlySquare = YPConfig.library.onlySquare
     public var isShown = true
+    public var spinnerIsShown = false
     
     private let spinner = UIActivityIndicatorView(style: .white)
     private var shouldCropToSquare = YPConfig.library.isSquareByDefault
@@ -179,7 +180,7 @@ extension YPAssetViewContainer: UIGestureRecognizerDelegate {
     }
     
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        return spinnerView.alpha == 0 && !(touch.view is UIButton)
+        return !spinnerIsShown && !(touch.view is UIButton)
     }
     
     @objc

--- a/Source/Pages/Gallery/YPAssetViewContainer.swift
+++ b/Source/Pages/Gallery/YPAssetViewContainer.swift
@@ -179,7 +179,7 @@ extension YPAssetViewContainer: UIGestureRecognizerDelegate {
     }
     
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        return !(touch.view is UIButton)
+        return spinnerView.alpha == 0 && !(touch.view is UIButton)
     }
     
     @objc

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -23,7 +23,15 @@ final class YPLibraryView: UIView {
     let maxNumberWarningLabel = UILabel()
     let progressView = UIProgressView()
     let line = UIView()
-    var shouldShowLoader = false
+    var shouldShowLoader = false {
+        didSet {
+            DispatchQueue.main.async {
+                self.assetViewContainer.squareCropButton.isEnabled = !self.shouldShowLoader
+                self.assetViewContainer.multipleSelectionButton.isEnabled = !self.shouldShowLoader
+                self.shouldShowLoader ? self.hideOverlayView() : ()
+            }
+        }
+    }
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -28,6 +28,7 @@ final class YPLibraryView: UIView {
             DispatchQueue.main.async {
                 self.assetViewContainer.squareCropButton.isEnabled = !self.shouldShowLoader
                 self.assetViewContainer.multipleSelectionButton.isEnabled = !self.shouldShowLoader
+                self.assetViewContainer.spinnerIsShown = self.shouldShowLoader
                 self.shouldShowLoader ? self.hideOverlayView() : ()
             }
         }

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -195,6 +195,10 @@ open class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     
     @objc
     func navBarTapped() {
+        guard !(libraryVC?.isProcessing ?? false) else {
+            return
+        }
+        
         let vc = YPAlbumVC(albumsManager: albumsManager)
         let navVC = UINavigationController(rootViewController: vc)
         navVC.navigationBar.tintColor = .ypLabel


### PR DESCRIPTION
- disable squareCropButton and multipleSelectionButton
- disable gestureRecognizer
- disable navBar button for the album setting