### PR TITLE
Fix for #610 -> Flip and shot button should not able to clicked at the sime time.

### DIFF
--- a/Source/Pages/Photo/YPCameraVC.swift
+++ b/Source/Pages/Photo/YPCameraVC.swift
@@ -48,6 +48,10 @@ internal final class YPCameraVC: UIViewController, UIGestureRecognizerDelegate, 
         v.shotButton.addTarget(self, action: #selector(shotButtonTapped), for: .touchUpInside)
         v.flipButton.addTarget(self, action: #selector(flipButtonTapped), for: .touchUpInside)
         
+        // Prevent flip and shot button clicked at the same time
+        v.shotButton.isExclusiveTouch = true
+        v.flipButton.isExclusiveTouch = true
+        
         // Focus
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.focusTapped(_:)))
         tapRecognizer.delegate = self


### PR DESCRIPTION
If flip and shot button clicked at the same time, it causes the crash "No active and enabled video connection".

Same logic is being used iPhone built-in Camera; flip and shot button can't be clicked same time.

This change can fix the issue.