### PR TITLE
Fix Zero Selection Crash

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -444,6 +444,11 @@ internal class YPLibraryVC: UIViewController, YPPermissionCheckable {
                 return (asset, $0.cropRect)
             }
             
+            guard self.selectedItems.count > 0 else {
+                ypLog("Nothing selected. Cannot continue.")
+                return
+            }
+            
             // Multiple selection
             if self.multipleSelectionEnabled && self.selectedItems.count > 1 {
                 


### PR DESCRIPTION
A crash is possible if no items are selected and Next is clicked (Libary) if config is setup like the following:

```
config.library.preSelectItemOnMultipleSelection = false
config.library.defaultMultipleSelection = true
config.library.preselectedItems = []
config.library.maxNumberOfItems = 5
config.library.minNumberOfItems = 0
```