### PR TITLE
iOS 15 navigation bar UI problem 

### DIFF
--- a/Source/Helpers/Extensions/UINavigationBar+Extensions.swift
+++ b/Source/Helpers/Extensions/UINavigationBar+Extensions.swift
@@ -15,4 +15,20 @@ extension UINavigationBar {
         guard let font = font  else { return }
         self.titleTextAttributes = [NSAttributedString.Key.font: font]
     }
+
+    func configureNavigationBar(isTransculent: Bool, tintColor: UIColor) {
+        self.tintColor = .ypLabel
+
+        if #available(iOS 15.0, *) {
+            let appearance = standardAppearance
+            if isTransculent {
+                appearance.configureWithTransparentBackground()
+            } else {
+                appearance.configureWithOpaqueBackground()
+            }
+            scrollEdgeAppearance = appearance
+        } else {
+            self.isTranslucent = isTransculent
+        }
+    }
 }

--- a/Source/Helpers/Extensions/UINavigationBar+Extensions.swift
+++ b/Source/Helpers/Extensions/UINavigationBar+Extensions.swift
@@ -17,7 +17,7 @@ extension UINavigationBar {
     }
 
     func configureNavigationBar(isTransculent: Bool, tintColor: UIColor) {
-        self.tintColor = .ypLabel
+        self.tintColor = tintColor
 
         if #available(iOS 15.0, *) {
             let appearance = standardAppearance

--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -37,7 +37,6 @@ open class YPImagePicker: UINavigationController {
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen // Force .fullScreen as iOS 13 now shows modals as cards by default.
         picker.pickerVCDelegate = self
-        navigationBar.tintColor = .ypLabel
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -73,7 +72,7 @@ open class YPImagePicker: UINavigationController {
         }
         viewControllers = [picker]
         setupLoadingView()
-        navigationBar.isTranslucent = false
+        navigationBar.configureNavigationBar(isTransculent: false, tintColor: .ypLabel)
 
         picker.didSelectItems = { [weak self] items in
             // Use Fade transition instead of default push animation


### PR DESCRIPTION
configuration of navigation extension method added for changing transparency and tint color. 

With iOS 15 UINavigationBarAppearance should be used for setting transparency and opaque background. scrollEdgeAppearance should be set with current configuration because scrollable content aligns with the edge of the navigation bar.

Fix the issue -> https://github.com/Yummypets/YPImagePicker/issues/690