### PR TITLE
Photos permission issue fix in Spm fix 

### DIFF
--- a/Sources/YPImagePicker/Code/Pages/Photo/YPCameraVC.swift
+++ b/Sources/YPImagePicker/Code/Pages/Photo/YPCameraVC.swift
@@ -132,7 +132,7 @@ internal final class YPCameraVC: UIViewController, UIGestureRecognizerDelegate, 
     @objc
     func shotButtonTapped() {
         doAfterLibraryPermissionCheck { [weak self] in 
-            doAfterCameraPermissionCheck { [weak self] in
+            self?.doAfterCameraPermissionCheck { [weak self] in
                 self?.shoot()
             }
         }

--- a/Sources/YPImagePicker/Code/Pages/Photo/YPCameraVC.swift
+++ b/Sources/YPImagePicker/Code/Pages/Photo/YPCameraVC.swift
@@ -64,17 +64,19 @@ internal final class YPCameraVC: UIViewController, UIGestureRecognizerDelegate, 
     }
     
     func start() {
-        doAfterCameraPermissionCheck { [weak self] in
-            guard let previewContainer = self?.v.previewViewContainer else {
-                return
-            }
-
-            self?.photoCapture.start(with: previewContainer, completion: {
-                DispatchQueue.main.async {
-                    self?.isInited = true
-                    self?.updateFlashButtonUI()
+        doAfterLibraryPermissionCheck { [weak self] in
+            self?.doAfterCameraPermissionCheck { [weak self] in
+                guard let previewContainer = self?.v.previewViewContainer else {
+                    return
                 }
-            })
+                
+                self?.photoCapture.start(with: previewContainer, completion: {
+                    DispatchQueue.main.async {
+                        self?.isInited = true
+                        self?.updateFlashButtonUI()
+                    }
+                })
+            }
         }
     }
 

--- a/Sources/YPImagePicker/Code/Pages/Photo/YPCameraVC.swift
+++ b/Sources/YPImagePicker/Code/Pages/Photo/YPCameraVC.swift
@@ -131,8 +131,10 @@ internal final class YPCameraVC: UIViewController, UIGestureRecognizerDelegate, 
     
     @objc
     func shotButtonTapped() {
-        doAfterCameraPermissionCheck { [weak self] in
-            self?.shoot()
+        doAfterLibraryPermissionCheck { [weak self] in 
+            doAfterCameraPermissionCheck { [weak self] in
+                self?.shoot()
+            }
         }
     }
     


### PR DESCRIPTION
Make sure to have both Photos and camera permission In case of using the camera. If you lack photos permission in camera screen, you may get crash.
First library permission then camera permission to smooth out workflow.