### PR TITLE
fix: calculate squaredZoomScale when media asset is loaded

### DIFF
--- a/Source/Pages/Gallery/YPAssetZoomableView.swift
+++ b/Source/Pages/Gallery/YPAssetZoomableView.swift
@@ -75,6 +75,8 @@ final class YPAssetZoomableView: UIScrollView {
             strongSelf.videoView.setPreviewImage(preview)
             
             strongSelf.setAssetFrame(for: strongSelf.videoView, with: preview)
+
+            strongSelf.squaredZoomScale = strongSelf.calculateSquaredZoomScale()
             
             completion()
             
@@ -131,6 +133,8 @@ final class YPAssetZoomableView: UIScrollView {
                 // add update CropInfo after multiple
                 updateCropInfo()
             }
+
+            strongSelf.squaredZoomScale = strongSelf.calculateSquaredZoomScale()
             
             completion(isLowResIntermediaryImage)
         }


### PR DESCRIPTION
### What
The square crop button requires two taps initially to scale the selected media to square. Reason is that `squaredZoomScale` value isn't calculated until the very first call to `public func fitImage(_ fit: Bool, animated isAnimated: Bool = false)`. 

### How
Solution here is to calculate `squaredZoomScale` when the selected media is loaded.