### PR TITLE
fix ios 12 crash

### DIFF
--- a/Source/Helpers/Extensions/PHCachingImageManager+Extensions.swift
+++ b/Source/Helpers/Extensions/PHCachingImageManager+Extensions.swift
@@ -91,7 +91,7 @@ extension PHCachingImageManager {
         options.isNetworkAccessAllowed = true
 		// Get 2 results, one low res quickly and the high res one later.
         options.deliveryMode = .opportunistic
-        requestImage(for: asset, targetSize: PHImageManagerMaximumSize,
+        requestImage(for: asset, targetSize: CGSize(width: asset.pixelWidth, height: asset.pixelHeight),
 					 contentMode: .aspectFill, options: options) { result, info in
             guard let image = result else {
                 ypLog("No Result 🛑")


### PR DESCRIPTION
remove warning ["First stage of an opportunistic image request returned a non-table format image, this is not fatal, but it is unexpected"](https://stackoverflow.com/questions/55230259/phimagemanager-throws-first-stage-of-an-opportunistic-image-request-returned-a) that causes a crash while selecting multiple images 