### PR TITLE
fix changing albums crash

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -55,13 +55,13 @@ extension YPLibraryVC {
     // MARK: - Library collection view cell managing
     private func getSelectedIndexPaths(selectedItems: [YPLibrarySelection]) -> [IndexPath] {
         let collectionViewItemsCount = v.collectionView.numberOfItems(inSection: 0)
-        var SelectedIndexPaths = [IndexPath]()
+        var selectedIndexPaths = [IndexPath]()
         for item in selectedItems {
             if item.index < collectionViewItemsCount {
-                SelectedIndexPaths.append(IndexPath(row: item.index, section: 0))
+                selectedIndexPaths.append(IndexPath(row: item.index, section: 0))
             }
         }
-        return Array(Set(SelectedIndexPaths))
+        return Array(Set(selectedIndexPaths))
     }
     
     /// Removes cell from selection

--- a/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
+++ b/Source/Pages/Gallery/YPLibraryVC+CollectionView.swift
@@ -53,6 +53,16 @@ extension YPLibraryVC {
     }
     
     // MARK: - Library collection view cell managing
+    private func getSelectedIndexPaths(selectedItems: [YPLibrarySelection]) -> [IndexPath] {
+        let collectionViewItemsCount = v.collectionView.numberOfItems(inSection: 0)
+        var SelectedIndexPaths = [IndexPath]()
+        for item in selectedItems {
+            if item.index < collectionViewItemsCount {
+                SelectedIndexPaths.append(IndexPath(row: item.index, section: 0))
+            }
+        }
+        return Array(Set(SelectedIndexPaths))
+    }
     
     /// Removes cell from selection
     func deselect(indexPath: IndexPath) {
@@ -62,7 +72,7 @@ extension YPLibraryVC {
             selectedItems.remove(at: positionIndex)
 
             // Refresh the numbers
-            let selectedIndexPaths = selectedItems.map { IndexPath(row: $0.index, section: 0) }
+            let selectedIndexPaths = getSelectedIndexPaths(selectedItems: selectedItems)
             v.collectionView.reloadItems(at: selectedIndexPaths)
 			
             // Replace the current selected image with the previously selected one


### PR DESCRIPTION
steps to reproduce: 
you have 2 albums in you gallery (recents album (has 30 media items), screenshots album (has 9 media items))
note that (screenshots album) has the screenshots images in (recents album)
- open albums with many photos and videos (recents album). 
- select more than 9 media items from resects album for example select 15 media items. 
- go to album screenshots
- deselect last item selected 

 app will crash because reload items for selectedIndexPaths will reload 15 indexpath while screenshots albums collection view has only 9 indexpaths. 
 
 what i do: 
 change selectedIndexPaths variable to be have only 9 cells. 

