### PR TITLE
Update AVFileType+Extensions.swift

### DIFF
--- a/Source/Helpers/Extensions/AVFileType+Extensions.swift
+++ b/Source/Helpers/Extensions/AVFileType+Extensions.swift
@@ -4,18 +4,27 @@
 //
 //  Created by Nik Kov on 23.04.2018.
 //  Copyright © 2018 Yummypets. All rights reserved.
-//
+//  Updated by isa yeter on 12.06.2022.
 
 import AVFoundation
 import MobileCoreServices
 
 extension AVFileType {
-    /// Fetch and extension for a file from UTI string
     var fileExtension: String {
-        if let ext = UTTypeCopyPreferredTagWithClass(self as CFString,
-													 kUTTagClassFilenameExtension)?.takeRetainedValue() {
-            return ext as String
+        if #available(iOS 14.0, *) {
+            guard let type = UTType(self.rawValue),
+                  let preferredFilenameExtension = type.preferredFilenameExtension
+            else {
+                return "None"
+            }
+            return preferredFilenameExtension
         }
-        return "None"
+        // Fallback on earlier versions
+        else {
+            if let ext = UTTypeCopyPreferredTagWithClass(self as CFString, kUTTagClassFilenameExtension)?.takeRetainedValue() {
+                return ext as String
+            }
+            return "None"
+        }
     }
 }


### PR DESCRIPTION
when I'm using iOS13.5 simulator, everything works fine, however when I'm using iOS15 simulator, when I pick a video from photo library I got this error;

```
Could not calculate the thumbnail size.
Could not calculate the thumbnail size.
🖼 YPImagePicker. YPVideoFiltersVC.swift -> save() -> Export of the video failed. Reason: Optional(Error Domain=AVFoundationErrorDomain Code=-11838 "Operation Stopped" UserInfo={NSLocalizedFailureReason=The operation is not supported for this media., NSLocalizedDescription=Operation Stopped, NSUnderlyingError=0x6000015c81b0 {Error Domain=NSOSStatusErrorDomain Code=-16976 "(null)"}}) (line: 218)
```

with the configuration of:
```
config.video.fileType = .mp4
```

After analyzing your source code, I noticed that it returns "None" as the extension, I was suspected maybe this was the reason,I have fixed this function, everything works on iOS 15 simulator now.