### PR TITLE
Add 'autoZoomIn' config to Library

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -199,6 +199,9 @@ public struct YPConfigLibrary {
     /// Choose what media types are available in the library. Defaults to `.photo`.
     /// If you define custom options PHFetchOptions var, than this will not work.
     public var mediaType = YPlibraryMediaType.photo
+    
+    /// Automatic zoom after user selects photo.
+    public var autoZoomIn = false
 
     /// Initial state of multiple selection button.
     public var defaultMultipleSelection = false

--- a/Source/Pages/Gallery/YPAssetViewContainer.swift
+++ b/Source/Pages/Gallery/YPAssetViewContainer.swift
@@ -102,6 +102,10 @@ final class YPAssetViewContainer: UIView {
     // MARK: - Square button
 
     @objc public func squareCropButtonTapped() {
+        execPhotoZoom()
+    }
+    
+    public func execPhotoZoom() {
         let z = zoomableView.zoomScale
         shouldCropToSquare = (z >= 1 && z < zoomableView.squaredZoomScale)
         zoomableView.fitImage(shouldCropToSquare, animated: true)

--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -295,6 +295,9 @@ internal final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                 self.v.hideLoader()
                 self.delegate?.libraryViewFinishedLoading()
             }
+            if YPConfig.library.autoZoomIn {
+                self.v.assetViewContainer.execPhotoZoom()
+            }
         }
         
         let updateCropInfo = {


### PR DESCRIPTION
### What I have added
I think it would be convenient to add an auto-zoom function in the photo Library config. 
(At least I need to use this. 😆 )

```swift
// Example of use
config.library.autoZoomIn = true
```

### Description.
When the user tapped on a photo, in the preview area above, the user doesn't have to tap the zoom button every time, 
but it zoom automatically.

### What it actually looks like

https://user-images.githubusercontent.com/47549414/176991300-263f8a3c-79f3-43d6-81ce-2b112066330f.mov


