### PR TITLE
If onlySquare is enabled, execute fitImage on display.

### DIFF
--- a/Source/Pages/Gallery/YPAssetViewContainer.swift
+++ b/Source/Pages/Gallery/YPAssetViewContainer.swift
@@ -109,11 +109,6 @@ final class YPAssetViewContainer: UIView {
 
     /// Update only UI of square crop button.
     public func updateSquareCropButtonState() {
-        guard !isMultipleSelectionEnabled else {
-            // If multiple selection enabled, the squareCropButton is not visible
-            squareCropButton.isHidden = true
-            return
-        }
         guard !onlySquare else {
             // If only square enabled, than the squareCropButton is not visible
             squareCropButton.isHidden = true


### PR DESCRIPTION
#776 

To fix above issue.

If `onlySquare` is enabled when displaying an Asset, call `fitImage` to crop it to a square.

You can see how it works in the sample apps in the `feature/demo` branch.
https://github.com/hanawat/YPImagePicker/tree/feature/demo

| Before  | After |
| ------- | ----- |
| <img width="300" alt="スクリーンショット 2022-12-15 21 33 07" src="https://user-images.githubusercontent.com/11912668/207861823-2e163102-a011-4130-bb0f-73b3cae8a41e.png"> | <img width="300" alt="スクリーンショット 2022-12-15 21 33 21" src="https://user-images.githubusercontent.com/11912668/207861863-67203b40-f0e1-4c30-8194-cfdf8d64b393.png">  |


