### PR TITLE
Update spinner appearance in YPAlbumVC

### DIFF
--- a/Source/Pages/Gallery/Album/YPAlbumView.swift
+++ b/Source/Pages/Gallery/Album/YPAlbumView.swift
@@ -18,6 +18,10 @@ class YPAlbumView: UIView {
         self.init(frame: .zero)
         
         if #available(iOS 13, *) {
+            let spinnerColor = UIColor { trait -> UIColor in
+                return trait.userInterfaceStyle == .dark ? .white : .gray
+            }
+            spinner.color = spinnerColor
             spinner.style = .large
         }
         

--- a/Source/Pages/Gallery/Album/YPAlbumView.swift
+++ b/Source/Pages/Gallery/Album/YPAlbumView.swift
@@ -17,6 +17,10 @@ class YPAlbumView: UIView {
     convenience init() {
         self.init(frame: .zero)
         
+        if #available(iOS 13, *) {
+            spinner.style = .large
+        }
+        
         subviews(
             tableView,
             spinner


### PR DESCRIPTION
Just change appearance of YPAlbumVC to adopt the iOS13 new spinner style and a better appearance in dark mode.

**Screenshots**
| Before | After | 
|-----|-----|
| <img src="https://user-images.githubusercontent.com/6509814/208956580-4126aacb-c3f8-4503-a372-0e78a4c8d478.png" width=320 /> | <img src="https://user-images.githubusercontent.com/6509814/208956646-876a409f-44c4-4f85-b0f5-83044def3231.png" width=320 /> | 
