### PR TITLE
fix for xcode 15 beta 2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/freshOS/Stevia",
         "state": {
           "branch": null,
-          "revision": "87dd17a86240f16788239a78dd8be11c4b013150",
-          "version": "4.8.0"
+          "revision": "cfb1a1d2159277bb553c3dc46f3f742c0275566d",
+          "version": "5.1.2"
         }
       }
     ]

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -140,7 +140,9 @@ public struct YPImagePickerConfiguration {
         ]
     
     /// Migration
-    
+    ///   Lawrence Norman: comment out for now so XCode 15 beta 2 compiles:
+    ///     resolves: Stored properties cannot be marked unavailable with '@available' #789
+    /*
     @available(iOS, obsoleted: 3.0.0, renamed: "video.compression")
     public var videoCompression: String = AVAssetExportPresetHighestQuality
     
@@ -179,6 +181,7 @@ public struct YPImagePickerConfiguration {
     
     @available(iOS, obsoleted: 3.0.0, renamed: "library.maxNumberOfItems")
     public var maxNumberOfItems = 1
+     */
     
 }
 


### PR DESCRIPTION
fix for xcode 15 beta 2: remove lines that cause: Stored properties cannot be marked unavailable with '@available' #789  -> In Xcode 15 beta 2