### PR TITLE
Use `UIApplication` and `view.windowScene.screen` instead of `UIScreen.main` on iOS 13.0 and later (#804)

### DIFF
--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -20,7 +20,15 @@ public struct YPImagePickerConfiguration {
     public static var widthOniPad: CGFloat = -1
     
     public static var screenWidth: CGFloat {
-		var screenWidth: CGFloat = UIScreen.main.bounds.width
+        var screenWidth: CGFloat = 0
+        
+        if #available(iOS 13.0, *) {
+            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            screenWidth = windowScene?.screen.bounds.width ?? .zero
+        } else {
+            screenWidth = UIScreen.main.bounds.width
+        }
+        
 		if UIDevice.current.userInterfaceIdiom == .pad && YPImagePickerConfiguration.widthOniPad > 0 {
 			screenWidth =  YPImagePickerConfiguration.widthOniPad
 		}

--- a/Source/Configuration/YPImagePickerConfiguration.swift
+++ b/Source/Configuration/YPImagePickerConfiguration.swift
@@ -24,7 +24,7 @@ public struct YPImagePickerConfiguration {
         
         if #available(iOS 13.0, *) {
             let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-            screenWidth = windowScene?.screen.bounds.width ?? .zero
+            screenWidth = windowScene?.screen.bounds.width ?? 1.0
         } else {
             screenWidth = UIScreen.main.bounds.width
         }

--- a/Source/Filters/Photo/YPFiltersView.swift
+++ b/Source/Filters/Photo/YPFiltersView.swift
@@ -32,7 +32,16 @@ class YPFiltersView: UIView {
             )
         )
         
-        let isIphone4 = UIScreen.main.bounds.height == 480
+        var height: CGFloat = 0
+        
+        if #available(iOS 13.0, *) {
+            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            height = windowScene?.screen.bounds.height ?? .zero
+        } else {
+            height = UIScreen.main.bounds.height
+        }
+        
+        let isIphone4 = height == 480
         let sideMargin: CGFloat = isIphone4 ? 20 : 0
         
         |-sideMargin-imageView.top(0)-sideMargin-|

--- a/Source/Filters/Photo/YPFiltersView.swift
+++ b/Source/Filters/Photo/YPFiltersView.swift
@@ -35,8 +35,7 @@ class YPFiltersView: UIView {
         var height: CGFloat = 0
         
         if #available(iOS 13.0, *) {
-            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-            height = windowScene?.screen.bounds.height ?? .zero
+            height = window?.windowScene?.screen.bounds.height ?? .zero
         } else {
             height = UIScreen.main.bounds.height
         }

--- a/Source/Filters/Photo/YPPhotoFiltersVC.swift
+++ b/Source/Filters/Photo/YPPhotoFiltersVC.swift
@@ -126,7 +126,16 @@ open class YPPhotoFiltersVC: UIViewController, IsMediaFilterVC, UIGestureRecogni
     
     fileprivate func thumbFromImage(_ img: UIImage) -> CIImage {
         let k = img.size.width / img.size.height
-        let scale = UIScreen.main.scale
+        
+        var scale: CGFloat = 0
+        
+        if #available(iOS 13.0, *) {
+            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            scale = windowScene?.screen.scale ?? .zero
+        } else {
+            scale = UIScreen.main.scale
+        }
+        
         let thumbnailHeight: CGFloat = 300 * scale
         let thumbnailWidth = thumbnailHeight * k
         let thumbnailSize = CGSize(width: thumbnailWidth, height: thumbnailHeight)

--- a/Source/Filters/Photo/YPPhotoFiltersVC.swift
+++ b/Source/Filters/Photo/YPPhotoFiltersVC.swift
@@ -130,8 +130,7 @@ open class YPPhotoFiltersVC: UIViewController, IsMediaFilterVC, UIGestureRecogni
         var scale: CGFloat = 0
         
         if #available(iOS 13.0, *) {
-            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-            scale = windowScene?.screen.scale ?? .zero
+            scale = window?.windowScene?.screen.scale ?? 1.0
         } else {
             scale = UIScreen.main.scale
         }

--- a/Source/Pages/Gallery/Album/YPAlbumsManager.swift
+++ b/Source/Pages/Gallery/Album/YPAlbumsManager.swift
@@ -40,7 +40,7 @@ class YPAlbumsManager {
                         
                         if #available(iOS 13.0, *) {
                             let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-                            deviceScale = windowScene?.screen.scale ?? .zero
+                            deviceScale = windowScene?.screen.scale ?? 1.0
                         } else {
                             deviceScale = UIScreen.main.scale
                         }

--- a/Source/Pages/Gallery/Album/YPAlbumsManager.swift
+++ b/Source/Pages/Gallery/Album/YPAlbumsManager.swift
@@ -36,7 +36,15 @@ class YPAlbumsManager {
                 if album.numberOfItems > 0 {
                     let r = PHAsset.fetchKeyAssets(in: assetCollection, options: nil)
                     if let first = r?.firstObject {
-                        let deviceScale = UIScreen.main.scale
+                        var deviceScale: CGFloat = 0
+                        
+                        if #available(iOS 13.0, *) {
+                            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+                            deviceScale = windowScene?.screen.scale ?? .zero
+                        } else {
+                            deviceScale = UIScreen.main.scale
+                        }
+                        
                         let targetSize = CGSize(width: 78*deviceScale, height: 78*deviceScale)
                         let options = PHImageRequestOptions()
                         options.isSynchronous = true

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -45,7 +45,7 @@ class LibraryMediaManager {
         
         if #available(iOS 13.0, *) {
             let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-            scale = windowScene?.screen.scale ?? .zero
+            scale = windowScene?.screen.scale ?? 1.0
         } else {
             scale = UIScreen.main.scale
         }

--- a/Source/Pages/Gallery/LibraryMediaManager.swift
+++ b/Source/Pages/Gallery/LibraryMediaManager.swift
@@ -40,7 +40,17 @@ class LibraryMediaManager {
     
     func updateCachedAssets(in collectionView: UICollectionView) {
         let screenWidth = YPImagePickerConfiguration.screenWidth
-        let size = screenWidth / 4 * UIScreen.main.scale
+        
+        var scale: CGFloat = 0
+        
+        if #available(iOS 13.0, *) {
+            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            scale = windowScene?.screen.scale ?? .zero
+        } else {
+            scale = UIScreen.main.scale
+        }
+        
+        let size = screenWidth / 4 * scale
         let cellSize = CGSize(width: size, height: size)
         
         var preheatRect = collectionView.bounds

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -160,9 +160,8 @@ internal final class YPLibraryView: UIView {
         var scale: CGFloat = 0
         
         if #available(iOS 13.0, *) {
-            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-            screenWidth = windowScene?.screen.bounds.width ?? .zero
-            scale = windowScene?.screen.scale ?? .zero
+            screenWidth = window?.windowScene?.screen.bounds.width ?? 1.0
+            scale = window?.windowScene?.screen.scale ?? 1.0
         } else {
             screenWidth = UIScreen.main.bounds.width
             scale = UIScreen.main.scale

--- a/Source/Pages/Gallery/YPLibraryView.swift
+++ b/Source/Pages/Gallery/YPLibraryView.swift
@@ -156,11 +156,22 @@ internal final class YPLibraryView: UIView {
     }
 
     func cellSize() -> CGSize {
-        var screenWidth: CGFloat = UIScreen.main.bounds.width
+        var screenWidth: CGFloat = 0
+        var scale: CGFloat = 0
+        
+        if #available(iOS 13.0, *) {
+            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            screenWidth = windowScene?.screen.bounds.width ?? .zero
+            scale = windowScene?.screen.scale ?? .zero
+        } else {
+            screenWidth = UIScreen.main.bounds.width
+            scale = UIScreen.main.scale
+        }
+        
         if UIDevice.current.userInterfaceIdiom == .pad && YPImagePickerConfiguration.widthOniPad > 0 {
             screenWidth =  YPImagePickerConfiguration.widthOniPad
         }
-        let size = screenWidth / 4 * UIScreen.main.scale
+        let size = screenWidth / 4 * scale
         return CGSize(width: size, height: size)
     }
 

--- a/Source/Pages/Photo/YPCameraView.swift
+++ b/Source/Pages/Photo/YPCameraView.swift
@@ -50,7 +50,16 @@ internal class YPCameraView: UIView, UIGestureRecognizerDelegate {
         }
         
         // Layout
-        let isIphone4 = UIScreen.main.bounds.height == 480
+        var height: CGFloat = 0
+        
+        if #available(iOS 13.0, *) {
+            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            height = windowScene?.screen.bounds.height ?? .zero
+        } else {
+            height = UIScreen.main.bounds.height
+        }
+        
+        let isIphone4 = height == 480
         let sideMargin: CGFloat = isIphone4 ? 20 : 0
         if YPConfig.onlySquareImagesFromCamera {
             layout(

--- a/Source/Pages/Photo/YPCameraView.swift
+++ b/Source/Pages/Photo/YPCameraView.swift
@@ -53,8 +53,7 @@ internal class YPCameraView: UIView, UIGestureRecognizerDelegate {
         var height: CGFloat = 0
         
         if #available(iOS 13.0, *) {
-            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-            height = windowScene?.screen.bounds.height ?? .zero
+            height = window?.windowScene?.screen.bounds.height ?? .zero
         } else {
             height = UIScreen.main.bounds.height
         }


### PR DESCRIPTION
`UIScree.main` will be deprecated in a future version of iOS.
I used Use `UIApplication` and `view.windowScene.screen` to get display's scale.

developer doc > [mian](https://developer.apple.com/documentation/uikit/uiscreen/1617815-main) already deprecated. It causes serious errors in the near future.

So have to change another way. And `UIApplication` and `view.windowScene.screen` is the others way of getting display's scale. That is available from `iOS 13.0`. This is why control flow has `iOS 13.0` condition.

Resolved: #804