### PR TITLE
previewViewContainer.backgroundColor

### DIFF
--- a/Source/Pages/Photo/YPCameraView.swift
+++ b/Source/Pages/Photo/YPCameraView.swift
@@ -97,7 +97,7 @@ internal class YPCameraView: UIView, UIGestureRecognizerDelegate {
         
         // Style
         backgroundColor = YPConfig.colors.photoVideoScreenBackgroundColor
-        previewViewContainer.backgroundColor = UIColor.ypLabel
+        previewViewContainer.backgroundColor = YPConfig.colors.photoVideoScreenBackgroundColor
         timeElapsedLabel.style { l in
             l.textColor = .white
             l.text = "00:00"


### PR DESCRIPTION
Configure the background color of previewViewContainer.backgroundColor using YPConfig.colors.photoVideoScreenBackgroundColor instead of UIColor.ypLabel.