### PR TITLE
Avoid force unwrapping in first selected assets

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -537,7 +537,11 @@ internal final class YPLibraryVC: UIViewController, YPPermissionCheckable {
                     self.delegate?.libraryViewFinishedLoading()
                 }
             } else {
-                let asset = selectedAssets.first!.asset
+                guard let asset = selectedAssets.first?.asset else {
+  					ypLog("No asset found in selection")
+  					return
+  				}
+				
                 switch asset.mediaType {
                 case .audio, .unknown:
                     return


### PR DESCRIPTION
Since reproducing the exact "empty assets" state is difficult, we rely on the safety of the `guard let` statement which prevents the runtime crash even if the underlying library fails to fetch an asset.